### PR TITLE
Adjust publish helpers for selective crate handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,100 +2,158 @@
 
 ## Code Style and Structure
 
-* **Code is for humans.** Write your code with clarity and empathy—assume a tired teammate will need to debug it at 3 a.m.
-* **Comment *why*, not *what*.** Explain assumptions, edge cases, trade-offs, or complexity. Don't echo the obvious.
-* **Clarity over cleverness.** Be concise, but favour explicit over terse or obscure idioms. Prefer code that's easy to follow.
-* **Use functions and composition.** Avoid repetition by extracting reusable logic. Prefer generators or comprehensions to imperative repetition when readable.
-* **Name things precisely.** Use clear, descriptive variable and function names. For booleans, prefer names with `is`, `has`, or `should`.
-* **Structure logically.** Each file should encapsulate a coherent module. Group related code (e.g., models + utilities + fixtures) close together.
-* **Group by feature, not layer.** Colocate views, logic, fixtures, and helpers related to a domain concept rather than splitting by type.
+* **Code is for humans.** Write your code with clarity and empathy—assume a
+  tired teammate will need to debug it at 3 a.m.
+* **Comment *why*, not *what*.** Explain assumptions, edge cases, trade-offs,
+  or complexity. Don't echo the obvious.
+* **Clarity over cleverness.** Be concise, but favour explicit over terse or
+  obscure idioms. Prefer code that's easy to follow.
+* **Use functions and composition.** Avoid repetition by extracting reusable
+  logic. Prefer generators or comprehensions to imperative repetition when
+  readable.
+* **Name things precisely.** Use clear, descriptive variable and function
+  names. For booleans, prefer names with `is`, `has`, or `should`.
+* **Structure logically.** Each file should encapsulate a coherent module.
+  Group related code (e.g., models + utilities + fixtures) close together.
+* **Group by feature, not layer.** Colocate views, logic, fixtures, and helpers
+  related to a domain concept rather than splitting by type.
 
 ## Documentation Maintenance
 
-*   **Reference:** Use the markdown files within the `docs/` directory as a knowledge base and source of truth for project requirements, dependency choices, and architectural decisions.
-*   **Update:** When new decisions are made, requirements change, libraries are added/removed, or architectural patterns evolve, **proactively update** the relevant file(s) in the `docs/` directory to reflect the latest state. Ensure the documentation remains accurate and current.
+* **Reference:** Use the markdown files within the `docs/` directory as a
+    knowledge base and source of truth for project requirements, dependency
+    choices, and architectural decisions.
+* **Update:** When new decisions are made, requirements change, libraries are
+    added/removed, or architectural patterns evolve, **proactively update** the
+    relevant file(s) in the `docs/` directory to reflect the latest state.
+    Ensure the documentation remains accurate and current.
 
 ## Guidelines for Code Changes & Testing
 
 When implementing changes, adhere to the following testing procedures:
 
 * **New Functionality:**
-  * Implement unit tests covering all new code units (functions, components, classes). Implement tests **before** implementing the unit.
-  * Implement behavioral tests that verify the end-to-end behavior of the new feature from a user interaction perspective.
-  * Ensure both unit and behavioral tests pass before considering the functionality complete.
+  * Implement unit tests covering all new code units (functions, components,
+    classes). Implement tests **before** implementing the unit.
+  * Implement behavioral tests that verify the end-to-end behavior of the new
+    feature from a user interaction perspective.
+  * Ensure both unit and behavioral tests pass before considering the
+    functionality complete.
 * **Bug Fixes:**
-  * Before fixing the bug, write a new test (unit or behavioral, whichever is most appropriate) that specifically targets and reproduces the bug. This test should initially fail.
+  * Before fixing the bug, write a new test (unit or behavioral, whichever is
+    most appropriate) that specifically targets and reproduces the bug. This
+    test should initially fail.
   * Implement the bug fix.
   * Verify that the new test now passes, along with all existing tests.
 * **Modifying Existing Functionality:**
-  * Identify the existing behavioral and unit tests relevant to the functionality being changed.
+  * Identify the existing behavioral and unit tests relevant to the
+    functionality being changed.
   * **First, modify the tests** to reflect the new requirements or behavior.
   * Run the tests; they should now fail.
   * Implement the code changes to the functionality.
   * Verify that the modified tests (and all other existing tests) now pass.
 * **Refactoring:**
-  * Identify or create a behavioral test that covers the functionality being refactored. Ensure this test passes **before** starting the refactor.
+  * Identify or create a behavioral test that covers the functionality being
+    refactored. Ensure this test passes **before** starting the refactor.
   * Perform the refactoring (e.g., extracting logic into a new unit).
-  * If new units are created (e.g., a new function or component), add unit tests for these extracted units.
-  * After the refactor, ensure the original behavioral test **still passes** without modification. Also ensure any new unit tests pass.
+  * If new units are created (e.g., a new function or component), add unit
+    tests for these extracted units.
+  * After the refactor, ensure the original behavioral test **still passes**
+    without modification. Also ensure any new unit tests pass.
 
 ## Change Quality & Committing
 
-* **Atomicity:** Aim for small, focused, atomic changes. Each change (and subsequent commit) should represent a single logical unit of work.
-* **Quality Gates:** Before considering a change complete or proposing a commit, ensure it meets the following criteria:
+* **Atomicity:** Aim for small, focused, atomic changes. Each change (and
+  subsequent commit) should represent a single logical unit of work.
+* **Quality Gates:** Before considering a change complete or proposing a
+  commit, ensure it meets the following criteria:
   * For Python files:
-    * **Testing:** Passes all relevant unit and behavioral tests according to the guidelines above.
-    * **Linting:** Passes lint checks (`ruff check` or integrated editor linting).
-    * **Formatting:** Adheres to formatting standards (`ruff format` or integrated editor formatting).
-    * **Typechecking:** Passes type checking (`pyright` or integrated editor type checking).
+    * **Testing:** Passes all relevant unit and behavioral tests according to
+      the guidelines above.
+    * **Linting:** Passes lint checks (`ruff check` or integrated editor
+      linting).
+    * **Formatting:** Adheres to formatting standards (`ruff format` or
+      integrated editor formatting).
+    * **Typechecking:** Passes type checking (`pyright` or integrated editor
+      type checking).
   * For TypeScript files:
-    * **Testing:** Passes all relevant unit and behavioral tests according to the guidelines above.
-    * **Linting:** Passes lint checks (`biome check .` or integrated editor linting).
-    * **Formatting:** Adheres to formatting standards (`biome check --apply .` or integrated editor formatting).
-    * **TypeScript Compilation:** Compiles successfully without TypeScript errors (`tsc --noEmit`).
-  
+    * **Testing:** Passes all relevant unit and behavioral tests according to
+      the guidelines above.
+    * **Linting:** Passes lint checks (`biome check .` or integrated editor
+      linting).
+    * **Formatting:** Adheres to formatting standards (`biome check --apply .`
+      or integrated editor formatting).
+    * **TypeScript Compilation:** Compiles successfully without TypeScript
+      errors (`tsc --noEmit`).
+
   * For Markdown files (`.md` only):
-    * **Linting:** Passes lint checks (`markdownlint filename.md` or integrated editor linting).
+    * **Linting:** Passes lint checks (`markdownlint filename.md` or integrated
+      editor linting).
     * **Mermaid diagrams:** Passes validation using nixie (`nixie filename.md`)
 * **Committing:**
   * Only changes that meet all the quality gates above should be committed.
-  * Write clear, descriptive commit messages summarizing the change, following these formatting guidelines:
-    * **Imperative Mood:** Use the imperative mood in the subject line (e.g., "Fix bug", "Add feature" instead of "Fixed bug", "Added feature").
-    * **Subject Line:** The first line should be a concise summary of the change (ideally 50 characters or less).
-    * **Body:** Separate the subject from the body with a blank line. Subsequent lines should explain the *what* and *why* of the change in more detail, including rationale, goals, and scope. Wrap the body at 72 characters.
-    * **Formatting:** Use Markdown for any formatted text (like bullet points or code snippets) within the commit message body.
+  * Write clear, descriptive commit messages summarizing the change, following
+    these formatting guidelines:
+    * **Imperative Mood:** Use the imperative mood in the subject line (e.g.,
+      "Fix bug", "Add feature" instead of "Fixed bug", "Added feature").
+    * **Subject Line:** The first line should be a concise summary of the
+      change (ideally 50 characters or less).
+    * **Body:** Separate the subject from the body with a blank line.
+      Subsequent lines should explain the *what* and *why* of the change in
+      more detail, including rationale, goals, and scope. Wrap the body at 72
+      characters.
+    * **Formatting:** Use Markdown for any formatted text (like bullet points
+      or code snippets) within the commit message body.
   * Do not commit changes that fail any of the quality gates.
 
 ## Refactoring Heuristics & Workflow
 
-* **Recognizing Refactoring Needs:** Regularly assess the codebase for potential refactoring opportunities. Consider refactoring when you observe:
-  * **Long Methods/Functions:** Functions or methods that are excessively long or try to do too many things.
-  * **Duplicated Code:** Identical or very similar code blocks appearing in multiple places.
-  * **Complex Conditionals:** Deeply nested or overly complex `if`/`else` or `switch` statements (high cyclomatic complexity).
-  * **Large Code Blocks for Single Values:** Significant chunks of logic dedicated solely to calculating or deriving a single value.
-  * **Primitive Obsession / Data Clumps:** Groups of simple variables (strings, numbers, booleans) that are frequently passed around together, often indicating a missing class or object structure.
-  * **Excessive Parameters:** Functions or methods requiring a very long list of parameters.
-  * **Feature Envy:** Methods that seem more interested in the data of another class/object than their own.
-  * **Shotgun Surgery:** A single change requiring small modifications in many different classes or functions.
-* **Post-Commit Review:** After committing a functional change or bug fix (that meets all quality gates), review the changed code and surrounding areas using the heuristics above.
+* **Recognizing Refactoring Needs:** Regularly assess the codebase for
+  potential refactoring opportunities. Consider refactoring when you observe:
+  * **Long Methods/Functions:** Functions or methods that are excessively long
+    or try to do too many things.
+  * **Duplicated Code:** Identical or very similar code blocks appearing in
+    multiple places.
+  * **Complex Conditionals:** Deeply nested or overly complex `if`/`else` or
+    `switch` statements (high cyclomatic complexity).
+  * **Large Code Blocks for Single Values:** Significant chunks of logic
+    dedicated solely to calculating or deriving a single value.
+  * **Primitive Obsession / Data Clumps:** Groups of simple variables (strings,
+    numbers, booleans) that are frequently passed around together, often
+    indicating a missing class or object structure.
+  * **Excessive Parameters:** Functions or methods requiring a very long list
+    of parameters.
+  * **Feature Envy:** Methods that seem more interested in the data of another
+    class/object than their own.
+  * **Shotgun Surgery:** A single change requiring small modifications in many
+    different classes or functions.
+* **Post-Commit Review:** After committing a functional change or bug fix (that
+  meets all quality gates), review the changed code and surrounding areas using
+  the heuristics above.
 * **Separate Atomic Refactors:** If refactoring is deemed necessary:
-  * Perform the refactoring as a **separate, atomic commit** *after* the functional change commit.
-  * Ensure the refactoring adheres to the testing guidelines (behavioral tests pass before and after, unit tests added for new units).
+  * Perform the refactoring as a **separate, atomic commit** *after* the
+    functional change commit.
+  * Ensure the refactoring adheres to the testing guidelines (behavioral tests
+    pass before and after, unit tests added for new units).
   * Ensure the refactoring commit itself passes all quality gates.
-
-
 
 ## Python Development Guidelines
 
-For Python development, refer to the detailed guidelines in the `.rules/` directory:
+For Python development, refer to the detailed guidelines in the `.rules/`
+directory:
 
-* [Python Code Style Guidelines](.rules/python-00.md) - Core Python 3.13 style conventions
-* [Python Context Managers](.rules/python-context-managers.md) - Best practices for context managers
+* [Python Code Style Guidelines](.rules/python-00.md) - Core Python 3.13 style
+  conventions
+* [Python Context Managers](.rules/python-context-managers.md) - Best practices
+  for context managers
 * [Python Exception Design, Raising, Handling and Logging](.rules/python-exception-design-raising-handling-and-logging.md)
-  - Exceptions and logging patterns
-* [Python Generators](.rules/python-generators.md) - Generator and iterator patterns
-* [Python Project Configuration](.rules/python-pyproject.md) - pyproject.toml and packaging
-* [Python Return Patterns](.rules/python-return.md) - Function return conventions
+  * Exceptions and logging patterns
+* [Python Generators](.rules/python-generators.md) - Generator and iterator
+  patterns
+* [Python Project Configuration](.rules/python-pyproject.md) - pyproject.toml
+  and packaging
+* [Python Return Patterns](.rules/python-return.md) - Function return
+  conventions
 * [Python Typing](.rules/python-typing.md) - Type annotation best practices
 
 Additional docs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,10 @@
+[workspace]
+members = [
+  "crates/rstest-bdd",
+  "crates/rstest-bdd-macros",
+  "crates/rstest-bdd-patterns",
+  "crates/cargo-bdd"
+]
+
+[workspace.package]
+version = "0.0.0"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # crate-tools
 
 Example package generated from this Copier template.
-
-

--- a/crate_tools/__init__.py
+++ b/crate_tools/__init__.py
@@ -3,4 +3,3 @@
 from __future__ import annotations
 
 PACKAGE_NAME = "crate_tools"
-

--- a/crate_tools/publish_patch.py
+++ b/crate_tools/publish_patch.py
@@ -104,6 +104,7 @@ def apply_replacements(
     >>> apply_replacements('rstest-bdd', tmp, '1.2.3')
     >>> 'version = "1.2.3"' in tmp.read_text()
     True
+
     """
     document = parse(manifest.read_text(encoding="utf-8"))
     patches = REPLACEMENTS.get(crate)
@@ -168,6 +169,7 @@ def update_dependency(
     ... )
     >>> dict(doc['dependencies']['foo'])['version']
     '1.0.0'
+
     """
     try:
         section = document[patch.section]
@@ -208,6 +210,7 @@ def extract_existing_items(value: object) -> tuple[tuple[str, object], ...]:
     >>> items = extract_existing_items(table['dependencies']['foo'])
     >>> dict(items)
     {'default-features': False}
+
     """
     if isinstance(value, (Table, InlineTable)):
         return tuple(
@@ -252,6 +255,7 @@ def build_inline_dependency(
     {'path': '../foo', 'version': '1.0.0'}
     >>> dict(build_inline_dependency((), '../foo', '1.0.0', include_local_path=False))
     {'version': '1.0.0'}
+
     """
     dependency = inline_table()
     if include_local_path:
@@ -301,6 +305,7 @@ def main() -> None:
     ...     sys.argv = argv
     >>> 'version = "1.2.3"' in tmp.read_text()
     True
+
     """
     parser = argparse.ArgumentParser(
         description="Adjust workspace manifests for publish-check packaging."

--- a/crate_tools/publish_workspace_archive.py
+++ b/crate_tools/publish_workspace_archive.py
@@ -5,10 +5,11 @@ publish automation. They deliberately keep filesystem side effects scoped to the
 provided destination so callers can stage archives without mutating the working
 copy.
 
-Example
+Example:
 -------
 >>> from pathlib import Path
 >>> export_workspace(Path("/tmp/release-staging"))
+
 """
 
 from __future__ import annotations
@@ -106,6 +107,7 @@ def export_workspace(destination: Path) -> None:
     None
         The repository snapshot is written directly to ``destination`` and the
         export honours ``GIT_ARCHIVE_TIMEOUT_S`` to bound ``git`` execution.
+
     """
     destination = Path(destination)
     destination.mkdir(parents=True, exist_ok=True)

--- a/crate_tools/publish_workspace_dependencies.py
+++ b/crate_tools/publish_workspace_dependencies.py
@@ -55,14 +55,13 @@ def apply_workspace_replacements(
     workspace_root = Path(workspace_root)
     if crates is None:
         targets: typ.Final[tuple[str, ...]] = tuple(REPLACEMENTS)
+        unknown: set[str] = set()
     else:
-        unknown = tuple(crate for crate in crates if crate not in REPLACEMENTS)
-        if unknown:
-            formatted = ", ".join(repr(crate) for crate in unknown)
-            message = "unknown crates: " + formatted
-            raise SystemExit(message)
+        unknown = {crate for crate in crates if crate not in REPLACEMENTS}
         targets = crates
     for crate in targets:
+        if crate in unknown:
+            continue
         manifest = workspace_root / "crates" / crate / "Cargo.toml"
         apply_replacements(
             crate,

--- a/crate_tools/publish_workspace_dependencies.py
+++ b/crate_tools/publish_workspace_dependencies.py
@@ -55,21 +55,18 @@ def apply_workspace_replacements(
     --------
     >>> from pathlib import Path
     >>> apply_workspace_replacements(Path("."), "1.2.3", include_local_path=False)
+
     """
     workspace_root = Path(workspace_root)
+    unknown: set[str] = set()
     if crates is None:
         targets: typ.Final[tuple[str, ...]] = tuple(REPLACEMENTS)
-        unknown: set[str] = set()
     else:
         unknown = {crate for crate in crates if crate not in REPLACEMENTS}
-        if unknown:
-            formatted = ", ".join(sorted(unknown))
-            LOGGER.warning(
-                "Skipping crates without replacement configuration: %s",
-                formatted,
-            )
-        targets = tuple(crate for crate in crates if crate not in unknown)
+        targets = crates
     for crate in targets:
+        if crate in unknown:
+            continue
         manifest = workspace_root / "crates" / crate / "Cargo.toml"
         apply_replacements(
             crate,

--- a/crate_tools/publish_workspace_dependencies.py
+++ b/crate_tools/publish_workspace_dependencies.py
@@ -63,9 +63,7 @@ def apply_workspace_replacements(
         unknown = {crate for crate in crates if crate not in REPLACEMENTS}
         if unknown:
             formatted = ", ".join(sorted(unknown))
-            LOGGER.warning(
-                "Skipping crates without replacement entries: %s", formatted
-            )
+            LOGGER.warning("Skipping crates without replacement entries: %s", formatted)
         targets = crates
     for crate in targets:
         if crate in unknown:

--- a/crate_tools/publish_workspace_dependencies.py
+++ b/crate_tools/publish_workspace_dependencies.py
@@ -63,6 +63,11 @@ def apply_workspace_replacements(
         targets: typ.Final[tuple[str, ...]] = tuple(REPLACEMENTS)
     else:
         unknown = {crate for crate in crates if crate not in REPLACEMENTS}
+        if unknown:
+            formatted = ", ".join(sorted(unknown))
+            LOGGER.warning(
+                "Skipping crates without replacement entries: %s", formatted
+            )
         targets = crates
     for crate in targets:
         if crate in unknown:

--- a/crate_tools/publish_workspace_dependencies.py
+++ b/crate_tools/publish_workspace_dependencies.py
@@ -28,6 +28,9 @@ def apply_workspace_replacements(
 ) -> None:
     """Rewrite workspace dependency declarations for publish workflows.
 
+    Crates lacking replacement configuration are reported via a warning and left
+    unchanged so publish runs can continue updating the remaining manifests.
+
     Parameters
     ----------
     workspace_root : Path
@@ -38,18 +41,13 @@ def apply_workspace_replacements(
         Toggle whether rewritten dependencies retain their relative path entries.
     crates : tuple[str, ...] | None, optional
         Subset of crates to update; default rewrites every crate with
-        replacements.
+        replacements. Crates without replacement configuration are skipped and
+        left untouched so callers can safely request broader sets.
 
     Returns
     -------
     None
         All matching manifests are rewritten in place.
-
-    Raises
-    ------
-    SystemExit
-        Raised when a manifest cannot be rewritten due to a missing replacement
-        entry.
 
     Examples
     --------

--- a/crate_tools/publish_workspace_dependencies.py
+++ b/crate_tools/publish_workspace_dependencies.py
@@ -68,6 +68,7 @@ def apply_workspace_replacements(
 
     """
     workspace_root = Path(workspace_root)
+    unknown: set[str] = set()
     targets, unknown = _compute_valid_targets(crates)
     if unknown:
         formatted = ", ".join(sorted(unknown))

--- a/crate_tools/publish_workspace_members.py
+++ b/crate_tools/publish_workspace_members.py
@@ -116,5 +116,10 @@ def _should_write_manifest(*, changed: bool, document: TOMLDocument) -> bool:
 
 def _format_multiline_members_if_needed(members: Array) -> None:
     """Ensure ``members`` is rendered as multiline when it spans lines."""
-    if "\n" in members.as_string():
-        members.multiline(multiline=True)
+    should_multiline = "\n" in members.as_string()
+    members.multiline(multiline=should_multiline)
+
+    def _is_multiline() -> bool:
+        return bool(getattr(members, "_multiline", False))
+
+    members.is_multiline = _is_multiline  # type: ignore[attr-defined]

--- a/crate_tools/publish_workspace_members.py
+++ b/crate_tools/publish_workspace_members.py
@@ -7,6 +7,7 @@ manifest structure.
 
 from __future__ import annotations
 
+import functools
 import typing as typ
 from pathlib import Path
 
@@ -114,12 +115,24 @@ def _should_write_manifest(*, changed: bool, document: TOMLDocument) -> bool:
     return changed and document.get("workspace") is not None
 
 
+def _members_is_multiline(members: Array) -> bool:
+    """Return the multiline flag recorded on ``members`` arrays."""
+    return bool(getattr(members, "_multiline", False))
+
+
 def _format_multiline_members_if_needed(members: Array) -> None:
-    """Ensure ``members`` is rendered as multiline when it spans lines."""
+    """Ensure ``members`` renders multiline and expose the state for callers.
+
+    The function toggles TOMLKit's multiline rendering when the serialised array
+    spans multiple lines and attaches an ``is_multiline`` helper so downstream
+    logic can observe the state. The helper reads the private ``_multiline``
+    attribute that TOMLKit maintains.
+    """
     should_multiline = "\n" in members.as_string()
     members.multiline(multiline=should_multiline)
 
-    def _is_multiline() -> bool:
-        return bool(getattr(members, "_multiline", False))
-
-    members.is_multiline = _is_multiline  # type: ignore[attr-defined]
+    # ``is_multiline`` is dynamically attached for compatibility with existing
+    # consumers that query TOMLKit arrays for this helper.
+    members.is_multiline = functools.partial(  # type: ignore[attr-defined]
+        _members_is_multiline, members
+    )

--- a/crate_tools/publish_workspace_versioning.py
+++ b/crate_tools/publish_workspace_versioning.py
@@ -70,9 +70,15 @@ def _extract_section_lines(lines: list[str], workspace_index: int) -> list[str]:
         return lines[start:end]
 
     excerpt: list[str] = [lines[header_index]]
-    for cursor in range(header_index + 1, workspace_index):
-        if not lines[cursor].strip():
-            excerpt.append(lines[cursor])
+    # Include only blank lines between the previous header and the workspace
+    # section so diagnostics have immediate context without unrelated entries
+    # from earlier manifest sections.
+    blank_lines = [
+        lines[cursor]
+        for cursor in range(header_index + 1, workspace_index)
+        if not lines[cursor].strip()
+    ]
+    excerpt.extend(blank_lines)
     excerpt.extend(lines[workspace_index:end])
     return excerpt
 

--- a/crate_tools/run_publish_check.py
+++ b/crate_tools/run_publish_check.py
@@ -19,6 +19,7 @@ Run with custom timeout and workspace preservation::
 
     PUBLISH_CHECK_TIMEOUT_SECS=1200 PUBLISH_CHECK_KEEP_TMP=1 \
         python scripts/run_publish_check.py
+
 """
 
 # /// script
@@ -83,8 +84,8 @@ DEFAULT_LIVE_PUBLISH_COMMANDS: typ.Final[tuple[Command, ...]] = (
 )
 
 LOCKED_LIVE_PUBLISH_COMMANDS: typ.Final[tuple[Command, ...]] = (
-    ("cargo", "publish", "--dry-run", "--locked"),
-    ("cargo", "publish", "--locked"),
+    ("cargo", "publish", "--dry-run"),
+    ("cargo", "publish"),
 )
 
 LIVE_PUBLISH_COMMANDS: typ.Final[dict[str, tuple[Command, ...]]] = {
@@ -174,6 +175,7 @@ def build_cargo_command_context(
     >>> context = build_cargo_command_context("tools", Path("/tmp/workspace"))
     >>> context.crate
     'tools'
+
     """
     crate_dir = workspace_root / "crates" / crate
     env_overrides = {"CARGO_HOME": str(workspace_root / ".cargo-home")}
@@ -257,6 +259,7 @@ def _handle_command_failure(
     result
         The :class:`CommandResult` describing the invocation, including the
         resolved command line and captured output streams.
+
     """
     joined_command = shlex.join(result.command)
     LOGGER.error("cargo command failed for %s: %s", crate, joined_command)
@@ -312,6 +315,7 @@ def run_cargo_command(
     is omitted the ``PUBLISH_CHECK_TIMEOUT_SECS`` environment variable is
     consulted before falling back to the default. On failure the captured
     stdout and stderr are logged to aid debugging in CI environments.
+
     """
     _validate_cargo_command(command)
 
@@ -467,6 +471,7 @@ def publish_crate_commands(
     SystemExit
         Raised when ``crate`` has no live command sequence configured. The
         workflow aborts to avoid silently skipping new crates.
+
     """
     try:
         commands = LIVE_PUBLISH_COMMANDS[crate]
@@ -500,6 +505,7 @@ class CrateProcessingConfig:
         crate rather than once for the entire workspace.
     per_crate_cleanup : Callable[[Path, str], None] | None, optional
         Cleanup action executed after each crate has been processed.
+
     """
 
     strip_patch: bool
@@ -545,6 +551,7 @@ def _process_crates(
         ...     config,
         ...     lambda crate, *_: None,
         ... )
+
     """
     if not CRATE_ORDER:
         message = "CRATE_ORDER must not be empty"
@@ -594,6 +601,7 @@ def _process_crates_for_live_publish(workspace: Path, timeout_secs: int) -> None
 
         >>> tmp = Path("/tmp/workspace")  # doctest: +SKIP
         >>> _process_crates_for_live_publish(tmp, 900)  # doctest: +SKIP
+
     """
     config = CrateProcessingConfig(
         strip_patch=False,
@@ -621,6 +629,7 @@ def _process_crates_for_check(workspace: Path, timeout_secs: int) -> None:
 
         >>> tmp = Path("/tmp/workspace")  # doctest: +SKIP
         >>> _process_crates_for_check(tmp, 900)  # doctest: +SKIP
+
     """
 
     def _crate_action(crate: str, root: Path, *, timeout_secs: int) -> None:
@@ -650,6 +659,7 @@ def run_publish_check(*, keep_tmp: bool, timeout_secs: int, live: bool = False) 
 
         >>> run_publish_check(keep_tmp=True, timeout_secs=120)
         preserving workspace at /tmp/...  # doctest: +ELLIPSIS
+
     """
     if timeout_secs <= 0:
         message = "timeout-secs must be a positive integer"
@@ -708,6 +718,7 @@ def main(
     -------
     None
         This function executes for its side effects and returns ``None``.
+
     """
     run_publish_check(keep_tmp=keep_tmp, timeout_secs=timeout_secs, live=live)
 

--- a/crate_tools/run_publish_check.py
+++ b/crate_tools/run_publish_check.py
@@ -72,29 +72,13 @@ class CrateAction(typ.Protocol):
 
 CRATE_ORDER: typ.Final[tuple[str, ...]] = PUBLISHABLE_CRATES
 
-LOCKED_LIVE_CRATES: typ.Final[frozenset[str]] = frozenset({"cargo-bdd"})
-
-DEFAULT_LIVE_CRATES: typ.Final[tuple[str, ...]] = tuple(
-    crate for crate in PUBLISHABLE_CRATES if crate not in LOCKED_LIVE_CRATES
-)
-
-DEFAULT_LIVE_PUBLISH_COMMANDS: typ.Final[tuple[Command, ...]] = (
-    ("cargo", "publish", "--dry-run"),
-    ("cargo", "publish"),
-)
-
-LOCKED_LIVE_PUBLISH_COMMANDS: typ.Final[tuple[Command, ...]] = (
+LIVE_PUBLISH_COMMANDS_SEQUENCE: typ.Final[tuple[Command, ...]] = (
     ("cargo", "publish", "--dry-run"),
     ("cargo", "publish"),
 )
 
 LIVE_PUBLISH_COMMANDS: typ.Final[dict[str, tuple[Command, ...]]] = {
-    crate: (
-        LOCKED_LIVE_PUBLISH_COMMANDS
-        if crate in LOCKED_LIVE_CRATES
-        else DEFAULT_LIVE_PUBLISH_COMMANDS
-    )
-    for crate in PUBLISHABLE_CRATES
+    crate: LIVE_PUBLISH_COMMANDS_SEQUENCE for crate in PUBLISHABLE_CRATES
 }
 
 ALREADY_PUBLISHED_MARKERS: typ.Final[tuple[str, ...]] = (

--- a/crate_tools/run_publish_check.py
+++ b/crate_tools/run_publish_check.py
@@ -83,8 +83,8 @@ DEFAULT_LIVE_PUBLISH_COMMANDS: typ.Final[tuple[Command, ...]] = (
 )
 
 LOCKED_LIVE_PUBLISH_COMMANDS: typ.Final[tuple[Command, ...]] = (
-    ("cargo", "publish", "--dry-run"),
-    ("cargo", "publish"),
+    ("cargo", "publish", "--dry-run", "--locked"),
+    ("cargo", "publish", "--locked"),
 )
 
 LIVE_PUBLISH_COMMANDS: typ.Final[dict[str, tuple[Command, ...]]] = {

--- a/crate_tools/run_publish_check.py
+++ b/crate_tools/run_publish_check.py
@@ -83,8 +83,8 @@ DEFAULT_LIVE_PUBLISH_COMMANDS: typ.Final[tuple[Command, ...]] = (
 )
 
 LOCKED_LIVE_PUBLISH_COMMANDS: typ.Final[tuple[Command, ...]] = (
-    ("cargo", "publish", "--dry-run", "--locked"),
-    ("cargo", "publish", "--locked"),
+    ("cargo", "publish", "--dry-run"),
+    ("cargo", "publish"),
 )
 
 LIVE_PUBLISH_COMMANDS: typ.Final[dict[str, tuple[Command, ...]]] = {

--- a/crate_tools/unittests/publish_check/conftest.py
+++ b/crate_tools/unittests/publish_check/conftest.py
@@ -96,18 +96,20 @@ def fake_workspace(tmp_path: Path) -> Path:
 @pytest.fixture
 def mock_cargo_runner(
     monkeypatch: pytest.MonkeyPatch, run_publish_check_module: ModuleType
-) -> list[tuple[object, list[str], typ.Callable[[str, object], bool] | None]]:
+) -> list[tuple[object, tuple[str, ...], typ.Callable[[str, object], bool] | None]]:
     """Capture invocations made to ``run_cargo_command``."""
-    calls: list[tuple[object, list[str], typ.Callable[[str, object], bool] | None]] = []
+    calls: list[
+        tuple[object, tuple[str, ...], typ.Callable[[str, object], bool] | None]
+    ] = []
 
     def fake_run_cargo(
         context: run_publish_check_module.CargoCommandContext,
-        command: list[str],
+        command: typ.Sequence[str],
         *,
         on_failure: typ.Callable[[str, run_publish_check_module.CommandResult], bool]
         | None = None,
     ) -> None:
-        calls.append((context, command, on_failure))
+        calls.append((context, tuple(command), on_failure))
 
     monkeypatch.setattr(run_publish_check_module, "run_cargo_command", fake_run_cargo)
     return calls
@@ -168,7 +170,7 @@ class FakeCargo:
 
     def __getitem__(self, args: object) -> FakeCargoInvocation:
         """Return an invocation wrapper for the provided command arguments."""
-        extras = list(args) if isinstance(args, (list, tuple)) else [str(args)]
+        extras = list(args) if isinstance(args, list | tuple) else [str(args)]
         return FakeCargoInvocation(self._local, extras)
 
 

--- a/crate_tools/unittests/publish_check/test_command_handling.py
+++ b/crate_tools/unittests/publish_check/test_command_handling.py
@@ -24,7 +24,7 @@ if typ.TYPE_CHECKING:
         CommandFailureTestCase(
             crate="demo",
             result_kwargs={
-                "command": ["cargo", "check"],
+                "command": ("cargo", "check"),
                 "return_code": 7,
                 "stdout": "stdout text",
                 "stderr": "stderr text",
@@ -36,7 +36,7 @@ if typ.TYPE_CHECKING:
         CommandFailureTestCase(
             crate="fmt",
             result_kwargs={
-                "command": ["cargo", "fmt"],
+                "command": ("cargo", "fmt"),
                 "return_code": 1,
                 "stdout": "",
                 "stderr": "",
@@ -48,7 +48,7 @@ if typ.TYPE_CHECKING:
         CommandFailureTestCase(
             crate="fmt",
             result_kwargs={
-                "command": ["cargo", "fmt"],
+                "command": ("cargo", "fmt"),
                 "return_code": 5,
                 "stdout": b"binary stdout",
                 "stderr": b"binary stderr",
@@ -60,7 +60,7 @@ if typ.TYPE_CHECKING:
         CommandFailureTestCase(
             crate="fmt",
             result_kwargs={
-                "command": ["cargo", "fmt"],
+                "command": ("cargo", "fmt"),
                 "return_code": -9,
                 "stdout": "ignored",
                 "stderr": "ignored",
@@ -118,7 +118,7 @@ def test_run_cargo_command_streams_output(
     )
     run_publish_check_module.run_cargo_command(
         context,
-        ["cargo", "mock"],
+        ("cargo", "mock"),
     )
 
     captured = capsys.readouterr()
@@ -147,7 +147,7 @@ def test_run_cargo_command_uses_env_timeout(
     )
     run_publish_check_module.run_cargo_command(
         context,
-        ["cargo", "mock"],
+        ("cargo", "mock"),
     )
 
     assert fake_local.cwd_calls == [crate_dir]
@@ -174,7 +174,7 @@ def test_run_cargo_command_logs_failures(
         with pytest.raises(SystemExit) as excinfo:
             module.run_cargo_command(
                 context,
-                ["cargo", "failing"],
+                ("cargo", "failing"),
             )
     assert "exit code 3" in str(excinfo.value)
     assert "bad stdout" in cargo_test_context.caplog.text
@@ -215,12 +215,12 @@ def test_run_cargo_command_suppresses_failure_when_handler_accepts(
     )
     run_publish_check_module.run_cargo_command(
         context,
-        ["cargo", "oops"],
+        ("cargo", "oops"),
         on_failure=record_failure,
     )
 
     expected = run_publish_check_module.CommandResult(
-        command=["cargo", "oops"],
+        command=("cargo", "oops"),
         return_code=5,
         stdout="out",
         stderr="err",
@@ -268,12 +268,12 @@ def test_run_cargo_command_calls_default_when_handler_declines(
     with pytest.raises(SystemExit, match="default handler invoked"):
         run_publish_check_module.run_cargo_command(
             context,
-            ["cargo", "oops"],
+            ("cargo", "oops"),
             on_failure=decline_failure,
         )
 
     expected = run_publish_check_module.CommandResult(
-        command=["cargo", "oops"],
+        command=("cargo", "oops"),
         return_code=17,
         stdout="out",
         stderr="err",
@@ -303,7 +303,7 @@ def test_run_cargo_command_times_out(
     with pytest.raises(SystemExit) as excinfo:
         run_publish_check_module.run_cargo_command(
             context,
-            ["cargo", "wait"],
+            ("cargo", "wait"),
         )
     assert "timed out" in str(excinfo.value)
 
@@ -334,7 +334,7 @@ def test_publish_one_command_handles_already_published(
         on_failure: typ.Callable[[str, run_publish_check_module.CommandResult], bool],
     ) -> None:
         result = run_publish_check_module.CommandResult(
-            command=command,
+            command=tuple(command),
             return_code=1,
             stdout="dry run output",
             stderr="error: crate already exists on crates.io index",
@@ -350,7 +350,7 @@ def test_publish_one_command_handles_already_published(
         handled = run_publish_check_module._publish_one_command(
             "demo",
             workspace,
-            ["cargo", "publish"],
+            ("cargo", "publish"),
             timeout_secs=11,
         )
 
@@ -377,7 +377,7 @@ def test_publish_one_command_detects_markers_case_insensitive(
         on_failure: typ.Callable[[str, run_publish_check_module.CommandResult], bool],
     ) -> None:
         result = run_publish_check_module.CommandResult(
-            command=command,
+            command=tuple(command),
             return_code=1,
             stdout="WARNING: crate VERSION ALREADY EXISTS",  # intentionally upper case
             stderr="",
@@ -393,7 +393,7 @@ def test_publish_one_command_detects_markers_case_insensitive(
     handled = run_publish_check_module._publish_one_command(
         "demo",
         workspace,
-        ["cargo", "publish"],
+        ("cargo", "publish"),
     )
 
     assert handled is True
@@ -427,7 +427,7 @@ def test_contains_already_published_marker_handles_known_messages(
 ) -> None:
     """Confirm recognised crates.io markers trigger the already-published path."""
     result = run_publish_check_module.CommandResult(
-        command=["cargo", "publish"],
+        command=("cargo", "publish"),
         return_code=101,
         stdout=stdout,
         stderr=stderr,
@@ -462,7 +462,7 @@ def test_publish_one_command_returns_false_on_success(
     handled = run_publish_check_module._publish_one_command(
         "demo",
         workspace,
-        ["cargo", "publish"],
+        ("cargo", "publish"),
         timeout_secs=7,
     )
 
@@ -491,7 +491,7 @@ def test_publish_one_command_propagates_unhandled_errors(
         on_failure: typ.Callable[[str, run_publish_check_module.CommandResult], bool],
     ) -> None:
         result = run_publish_check_module.CommandResult(
-            command=command,
+            command=tuple(command),
             return_code=2,
             stdout="",  # stdout intentionally empty
             stderr="error: publishing failed",
@@ -508,7 +508,7 @@ def test_publish_one_command_propagates_unhandled_errors(
         run_publish_check_module._publish_one_command(
             "demo",
             workspace,
-            ["cargo", "publish"],
+            ("cargo", "publish"),
         )
 
 
@@ -516,11 +516,11 @@ def test_publish_one_command_propagates_unhandled_errors(
     ("function_and_command", "test_scenario"),
     [
         (
-            ("package_crate", ["cargo", "package", "--allow-dirty", "--no-verify"]),
+            ("package_crate", ("cargo", "package", "--allow-dirty", "--no-verify")),
             ("demo", 42),
         ),
         (
-            ("check_crate", ["cargo", "check", "--all-features"]),
+            ("check_crate", ("cargo", "check", "--all-features")),
             ("demo", 17),
         ),
     ],
@@ -529,9 +529,9 @@ def test_publish_one_command_propagates_unhandled_errors(
 def test_cargo_commands_invoke_runner(
     run_publish_check_module: ModuleType,
     mock_cargo_runner: list[
-        tuple[object, list[str], typ.Callable[[str, object], bool] | None]
+        tuple[object, tuple[str, ...], typ.Callable[[str, object], bool] | None]
     ],
-    function_and_command: tuple[str, list[str]],
+    function_and_command: tuple[str, tuple[str, ...]],
     test_scenario: tuple[str, int],
 ) -> None:
     """Ensure cargo helper wrappers delegate to ``run_cargo_command``."""

--- a/crate_tools/unittests/publish_check/test_dry_run_integration.py
+++ b/crate_tools/unittests/publish_check/test_dry_run_integration.py
@@ -152,6 +152,7 @@ class TestRunPublishCheckOrchestration:
         tuple
             The prepared workspace directory and the lists capturing recorded
             workspace steps, package invocations, and check invocations.
+
         """
         workspace_dir = self._create_test_workspace(
             monkeypatch, tmp_path, run_publish_check_module
@@ -174,6 +175,7 @@ class TestRunPublishCheckOrchestration:
         ----------
         run_publish_check_module:
             Module under test providing the ``run_publish_check`` entrypoint.
+
         """
         run_publish_check_module.run_publish_check(keep_tmp=False, timeout_secs=15)
 
@@ -196,6 +198,7 @@ class TestRunPublishCheckOrchestration:
             Captured invocations to ``package_crate``.
         check_calls:
             Captured invocations to ``check_crate``.
+
         """
         manifest_path = workspace_dir / "Cargo.toml"
         assert steps[:3] == [

--- a/crate_tools/unittests/publish_check/test_live_publish_integration.py
+++ b/crate_tools/unittests/publish_check/test_live_publish_integration.py
@@ -37,6 +37,7 @@ class TestRunPublishCheckLiveMode:
         -------
         tuple[Path, Path]
             The workspace directory and its manifest path.
+
         """
         workspace_dir = tmp_path / "live"
         workspace_dir.mkdir()
@@ -74,6 +75,7 @@ class TestRunPublishCheckLiveMode:
         tuple
             Recorded workspace steps and cargo invocations, including the
             resolved cargo contexts and optional failure callbacks.
+
         """
         steps, record = self._setup_recording_infrastructure()
         fake_apply, fake_remove = self._create_fake_functions(steps)
@@ -236,6 +238,7 @@ class TestRunPublishCheckLiveMode:
             Workspace directory that should be removed after execution.
         manifest:
             Workspace manifest used for assertions.
+
         """
         assert steps[:2] == [
             ("export", workspace_dir),

--- a/crate_tools/unittests/test_bump_version.py
+++ b/crate_tools/unittests/test_bump_version.py
@@ -18,7 +18,7 @@ from scripts.bump_version import (
 @pytest.mark.parametrize(
     "body, expected, extra",
     [
-        ("foo = \"^0.1\"", "foo = \"^1.2.3\"", None),
+        ('foo = "^0.1"', 'foo = "^1.2.3"', None),
         (
             'foo = { version = "~0.1", features = ["a"] }',
             'version = "~1.2.3"',
@@ -39,9 +39,9 @@ def test_updates_dependency_version(
 
 def test_preserves_trailing_comment_on_string_dependency() -> None:
     doc = tomlkit.parse('[dependencies]\nfoo = "^0.1"  # pinned for CI\n')
-    _update_dependency_version(doc, 'foo', '1.2.3')
+    _update_dependency_version(doc, "foo", "1.2.3")
     dumped = tomlkit.dumps(doc)
-    assert '# pinned for CI' in dumped, "must preserve trailing comment on value node"
+    assert "# pinned for CI" in dumped, "must preserve trailing comment on value node"
 
 
 def test_preserves_quote_style_on_string_dependency() -> None:
@@ -56,15 +56,17 @@ def test_preserves_quote_style_on_string_dependency() -> None:
 def test_missing_dependency_no_change() -> None:
     snippet = '[dependencies]\nbar = "0.1"'
     doc = tomlkit.parse(snippet)
-    _update_dependency_version(doc, 'foo', '1.2.3')
-    assert tomlkit.dumps(doc).strip() == snippet, "should be a no-op when dependency is absent"
+    _update_dependency_version(doc, "foo", "1.2.3")
+    assert tomlkit.dumps(doc).strip() == snippet, (
+        "should be a no-op when dependency is absent"
+    )
 
 
 def test_workspace_dependency_no_version_written() -> None:
-    doc = tomlkit.parse('[dependencies]\nfoo = { workspace = true }\n')
-    _update_dependency_version(doc, 'foo', '1.2.3')
-    deps = doc['dependencies']['foo']
-    assert 'version' not in deps, 'must not add version when workspace is true'
+    doc = tomlkit.parse("[dependencies]\nfoo = { workspace = true }\n")
+    _update_dependency_version(doc, "foo", "1.2.3")
+    deps = doc["dependencies"]["foo"]
+    assert "version" not in deps, "must not add version when workspace is true"
 
 
 @pytest.mark.parametrize(
@@ -122,7 +124,9 @@ ortho_config = { version = \"0.5.0-beta1\", features = [\"json5\", \"yaml\"] }
     _update_markdown_versions(md_path, "0.5.0")
 
     updated_lines = md_path.read_text().splitlines()
-    assert 'version = "0.5.0"' in "\n".join(updated_lines), "must bump version inside TOML fence"
+    assert 'version = "0.5.0"' in "\n".join(updated_lines), (
+        "must bump version inside TOML fence"
+    )
     assert updated_lines[-2] == (
         "# Enabling these features expands file formats; precedence stays: "
         "defaults < file < env < CLI."
@@ -133,11 +137,11 @@ ortho_config = { version = \"0.5.0-beta1\", features = [\"json5\", \"yaml\"] }
 @pytest.mark.parametrize(
     "snippet, expected_suffix",
     [
-        ("[dependencies]\northo_config = \"0\"\n", "\n"),
-        ("[dependencies]\northo_config = \"0\"\r\n", "\r\n"),
-        ("[dependencies]\northo_config = \"0\"\n\n", "\n\n"),
-        ("[dependencies]\northo_config = \"0\"\r\n\r\n", "\r\n\r\n"),
-        ("[dependencies]\northo_config = \"0\"", ""),
+        ('[dependencies]\northo_config = "0"\n', "\n"),
+        ('[dependencies]\northo_config = "0"\r\n', "\r\n"),
+        ('[dependencies]\northo_config = "0"\n\n', "\n\n"),
+        ('[dependencies]\northo_config = "0"\r\n\r\n', "\r\n\r\n"),
+        ('[dependencies]\northo_config = "0"', ""),
     ],
 )
 def test_replace_version_in_toml_preserves_suffix(
@@ -153,11 +157,11 @@ def test_replace_version_in_toml_preserves_suffix(
 @pytest.mark.parametrize(
     "snippet",
     [
-        "[dependencies]\nfoo = \"0\"\n",
-        "[dependencies]\nfoo = \"0\"\r\n",
-        "[dependencies]\nfoo = \"0\"\n\n",
-        "[dev-dependencies]\nfoo = \"0\"",
-        "[build-dependencies]\nfoo = \"0\"\r\n",
+        '[dependencies]\nfoo = "0"\n',
+        '[dependencies]\nfoo = "0"\r\n',
+        '[dependencies]\nfoo = "0"\n\n',
+        '[dev-dependencies]\nfoo = "0"',
+        '[build-dependencies]\nfoo = "0"\r\n',
     ],
 )
 def test_replace_version_in_toml_no_dependency_returns_input(snippet: str) -> None:

--- a/crate_tools/unittests/test_bump_version.py
+++ b/crate_tools/unittests/test_bump_version.py
@@ -3,12 +3,11 @@ from pathlib import Path
 import pytest
 import tomlkit
 
-from scripts.bump_version import (
+from crate_tools.bump_version import (
     _update_dependency_version,
     _update_markdown_versions,
-    replace_fences,
-    replace_version_in_toml,
 )
+from scripts.bump_version import replace_fences, replace_version_in_toml
 
 
 @pytest.mark.parametrize(

--- a/crate_tools/unittests/test_publish_workspace_dependencies.py
+++ b/crate_tools/unittests/test_publish_workspace_dependencies.py
@@ -1,0 +1,103 @@
+"""Tests for publish_workspace_dependencies helpers."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+import publish_workspace_dependencies as dependencies
+
+
+@pytest.fixture()
+def workspace_root(tmp_path: Path) -> Path:
+    """Create a temporary workspace layout for dependency rewrites."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "crates").mkdir()
+    return workspace
+
+
+def _write_rstest_manifest(crate_dir: Path) -> None:
+    manifest = crate_dir / "Cargo.toml"
+    manifest.write_text(
+        "\n".join(
+            (
+                "[package]",
+                'name = "rstest-bdd"',
+                'version = "0.0.1"',
+                "",
+                "[dependencies]",
+                'rstest-bdd-patterns = { path = "../rstest-bdd-patterns" }',
+                "",
+                "[dev-dependencies]",
+                'rstest-bdd-macros = { path = "../rstest-bdd-macros" }',
+            )
+        ),
+        encoding="utf-8",
+    )
+
+
+class TestApplyWorkspaceReplacements:
+    """Unit and behavioural coverage for dependency replacement workflows."""
+
+    def test_warns_and_skips_unknown_crates(
+        self,
+        workspace_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Log a warning when explicit crate lists contain unknown entries."""
+        crate_dir = workspace_root / "crates" / "rstest-bdd"
+        crate_dir.mkdir()
+        (crate_dir / "Cargo.toml").write_text("", encoding="utf-8")
+
+        captured: list[tuple[str, Path, str, bool]] = []
+
+        def fake_apply(
+            crate: str,
+            manifest: Path,
+            version: str,
+            *,
+            include_local_path: bool,
+        ) -> None:
+            captured.append((crate, manifest, version, include_local_path))
+
+        monkeypatch.setattr(dependencies, "apply_replacements", fake_apply)
+        caplog.set_level(logging.WARNING)
+
+        dependencies.apply_workspace_replacements(
+            workspace_root,
+            "1.2.3",
+            include_local_path=False,
+            crates=("rstest-bdd", "unknown-crate"),
+        )
+
+        expected_manifest = crate_dir / "Cargo.toml"
+        assert captured == [("rstest-bdd", expected_manifest, "1.2.3", False)]
+        assert "unknown-crate" in caplog.text
+
+    def test_updates_known_crates_when_unknown_requested(
+        self,
+        workspace_root: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Behavioural test covering the manifest rewrite flow."""
+        crate_dir = workspace_root / "crates" / "rstest-bdd"
+        crate_dir.mkdir()
+        _write_rstest_manifest(crate_dir)
+
+        caplog.set_level(logging.WARNING)
+
+        dependencies.apply_workspace_replacements(
+            workspace_root,
+            "2.0.0",
+            include_local_path=False,
+            crates=("rstest-bdd", "unknown-crate"),
+        )
+
+        manifest_text = (crate_dir / "Cargo.toml").read_text(encoding="utf-8")
+        assert manifest_text.count('version = "2.0.0"') == 2
+        assert "rstest-bdd-patterns" in manifest_text
+        assert "unknown-crate" in caplog.text

--- a/docs/scripting-standards.md
+++ b/docs/scripting-standards.md
@@ -29,8 +29,9 @@ as a default.
   integration constraints require them, and any exception must be documented
   inline.
 - Each script starts with an `uv` script block so runtime and dependency
-  expectations travel with the file. Prefer the shebang `#!/usr/bin/env -S uv
-  run python` followed by the metadata block shown in the example below.
+  expectations travel with the file. Prefer the shebang
+  `#!/usr/bin/env -S uv run python` followed by the metadata block shown in the
+  example below.
 - External processes are invoked via [`plumbum`](https://plumbum.readthedocs.io)
   to provide structured command execution rather than ad‑hoc shell strings.
 - File‑system interactions use `pathlib.Path`. Higher‑level operations (for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,9 @@ timeout = 30
 [tool.uv]
 package = true
 
+[tool.setuptools.packages.find]
+include = ["crate_tools", "crate_tools.*", "scripts", "scripts.*"]
+
 
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,5 @@
+"""Compat modules exposing legacy script entrypoints."""
+
+# This package intentionally re-exports tools from :mod:`crate_tools`
+# so existing imports like ``scripts.bump_version`` continue to work after
+# the CLI utilities were reorganised into the library package.

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,7 +1,5 @@
 """Compatibility wrapper for :mod:`crate_tools.bump_version`."""
 
-from __future__ import annotations
-
 from crate_tools.bump_version import (
     _update_dependency_version,
     _update_markdown_versions,

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,16 +1,12 @@
 """Compatibility wrapper for :mod:`crate_tools.bump_version`."""
 
 from crate_tools.bump_version import (
-    _update_dependency_version,
-    _update_markdown_versions,
     main,
     replace_fences,
     replace_version_in_toml,
 )
 
 __all__ = [
-    "_update_dependency_version",
-    "_update_markdown_versions",
     "main",
     "replace_fences",
     "replace_version_in_toml",

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,24 @@
+"""Compatibility wrapper for :mod:`crate_tools.bump_version`."""
+
+from __future__ import annotations
+
+from crate_tools.bump_version import (
+    _update_dependency_version,
+    _update_markdown_versions,
+    main,
+    replace_fences,
+    replace_version_in_toml,
+)
+
+__all__ = [
+    "_update_dependency_version",
+    "_update_markdown_versions",
+    "main",
+    "replace_fences",
+    "replace_version_in_toml",
+]
+
+if __name__ == "__main__":  # pragma: no cover - import-time compatibility shim
+    import sys
+
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary
- skip workspace replacement for crates without configured replacements instead of exiting
- align locked publish command sequences with standard publish flow

## Testing
- make lint

------
https://chatgpt.com/codex/tasks/task_e_68dc5fbc72a883229e3a4b55539ff16e

## Summary by Sourcery

Update publish helper scripts to skip unconfigured crates and align locked publish commands with the standard flow

Enhancements:
- Skip crates without configured replacements instead of exiting in publish workspace dependencies
- Remove `--locked` flag from locked publish commands to match standard publish flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Publishing tool now gracefully skips unrecognized workspace crates instead of failing.
  - Added compatibility script wrappers to preserve legacy CLI imports.
  - Declared a Cargo workspace with member crates.

- Chores
  - Simplified publish workflow by unifying dry-run and live command sequences for all crates.
  - Added setuptools package discovery config in pyproject.toml.

- Tests
  - New unit tests covering workspace dependency replacement behavior.

- Docs
  - Minor formatting and clarity edits to README, AGENTS.md, and scripting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->