### PR TITLE
Fix lint issues in version tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ lint: ruff ## Run linters
 	ruff check
 
 typecheck: build ty ## Run typechecking
-	ty check
+	ty check crate_tools/bump_version.py crate_tools/publish_patch.py crate_tools/publish_workspace_dependencies.py
 
 markdownlint: $(MDLINT) ## Lint Markdown files
 	find . -type f -name '*.md' \

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ MDLINT ?= $(shell which markdownlint)
 NIXIE ?= $(shell which nixie)
 MDFORMAT_ALL ?= $(shell which mdformat-all)
 TOOLS = $(MDFORMAT_ALL) ruff ty $(MDLINT) $(NIXIE) uv
+CRATE_TOOLS_SCRIPTS := $(sort $(wildcard crate_tools/*.py))
 VENV_TOOLS = pytest
 
 .PHONY: help all clean build build-release lint fmt check-fmt \
@@ -65,7 +66,7 @@ lint: ruff ## Run linters
 	ruff check
 
 typecheck: build ty ## Run typechecking
-	ty check --python-version 3.12 --extra-search-path crate_tools crate_tools/*.py
+	ty check --python-version 3.13 --extra-search-path crate_tools $(CRATE_TOOLS_SCRIPTS)
 
 markdownlint: $(MDLINT) ## Lint Markdown files
 	find . -type f -name '*.md' \

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ lint: ruff ## Run linters
 	ruff check
 
 typecheck: build ty ## Run typechecking
-	ty check crate_tools/bump_version.py crate_tools/publish_patch.py crate_tools/publish_workspace_dependencies.py
+	ty check --python-version 3.12 --extra-search-path crate_tools crate_tools/*.py
 
 markdownlint: $(MDLINT) ## Lint Markdown files
 	find . -type f -name '*.md' \

--- a/crate_tools/bump_version.py
+++ b/crate_tools/bump_version.py
@@ -166,15 +166,11 @@ def _update_package_version(
     '1'
 
     """
-    workspace = doc.get("workspace")
-    if isinstance(workspace, cabc.MutableMapping):
-        package = workspace.get("package")
-        if isinstance(package, cabc.MutableMapping):
+    match doc:
+        case {"workspace": {"package": cabc.MutableMapping() as package}}:
             package["version"] = version
-            return
-    package = doc.get("package")
-    if isinstance(package, cabc.MutableMapping):
-        package["version"] = version
+        case {"package": cabc.MutableMapping() as package}:
+            package["version"] = version
 
 
 def _extract_version_prefix(

--- a/crate_tools/publish_patch.py
+++ b/crate_tools/publish_patch.py
@@ -14,13 +14,13 @@ import dataclasses as dc
 import typing as typ
 from pathlib import Path
 
-if typ.TYPE_CHECKING:
-    import collections.abc as cabc
-else:  # pragma: no cover - runtime placeholder for type checking imports
-    cabc: typ.Any = None
-
 from tomlkit import TOMLDocument, dumps, inline_table, parse
 from tomlkit.items import InlineTable, Table
+
+if typ.TYPE_CHECKING:
+    from collections import abc as cabc
+else:  # pragma: no cover - runtime placeholder for type-only imports
+    cabc = typ.cast("type[object]", object)
 
 
 @dc.dataclass(frozen=True)
@@ -172,10 +172,14 @@ def update_dependency(
 
     """
     try:
-        section = document[patch.section]
+        section_item = document[patch.section]
     except KeyError as error:
         message = f"expected section [{patch.section}] in {manifest}"
         raise SystemExit(message) from error
+    if not isinstance(section_item, Table | InlineTable):
+        message = f"expected section [{patch.section}] in {manifest}"
+        raise SystemExit(message)
+    section = typ.cast("cabc.MutableMapping[str, typ.Any]", section_item)
     try:
         existing = section[patch.name]
     except KeyError as error:
@@ -213,9 +217,10 @@ def extract_existing_items(value: object) -> tuple[tuple[str, object], ...]:
 
     """
     if isinstance(value, Table | InlineTable):
+        table_value = typ.cast("cabc.Mapping[str, typ.Any]", value)
         return tuple(
             (key, item)
-            for key, item in value.items()
+            for key, item in table_value.items()
             if key not in {"workspace", "path", "version"}
         )
     return ()
@@ -257,13 +262,14 @@ def build_inline_dependency(
     {'version': '1.0.0'}
 
     """
-    dependency = inline_table()
+    dependency: InlineTable = inline_table()
     if include_local_path:
         dependency["path"] = path
     dependency["version"] = version
     for key, item in extra_items:
         dependency[key] = item
-    dependency.trailing_comma = False
+    cast_dependency = typ.cast("typ.Any", dependency)
+    cast_dependency.trailing_comma = False
     return dependency
 
 

--- a/crate_tools/publish_patch.py
+++ b/crate_tools/publish_patch.py
@@ -212,7 +212,7 @@ def extract_existing_items(value: object) -> tuple[tuple[str, object], ...]:
     {'default-features': False}
 
     """
-    if isinstance(value, (Table, InlineTable)):
+    if isinstance(value, Table | InlineTable):
         return tuple(
             (key, item)
             for key, item in value.items()

--- a/crate_tools/publish_workspace_dependencies.py
+++ b/crate_tools/publish_workspace_dependencies.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from publish_patch import REPLACEMENTS, apply_replacements
+from crate_tools.publish_patch import REPLACEMENTS, apply_replacements
 
 __all__ = ["apply_workspace_replacements"]
 

--- a/crate_tools/publish_workspace_dependencies.py
+++ b/crate_tools/publish_workspace_dependencies.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from crate_tools.publish_patch import REPLACEMENTS, apply_replacements
+if __package__ in {None, ""}:
+    from publish_patch import REPLACEMENTS, apply_replacements
+else:
+    from crate_tools.publish_patch import REPLACEMENTS, apply_replacements
 
 __all__ = ["apply_workspace_replacements"]
 

--- a/crate_tools/publish_workspace_dependencies.py
+++ b/crate_tools/publish_workspace_dependencies.py
@@ -22,7 +22,6 @@ def _compute_valid_targets(
     crates: tuple[str, ...] | None,
 ) -> tuple[tuple[str, ...], set[str]]:
     """Determine which crates should receive replacement updates."""
-
     if crates is None:
         return tuple(REPLACEMENTS), set()
 

--- a/crate_tools/publish_workspace_members.py
+++ b/crate_tools/publish_workspace_members.py
@@ -84,7 +84,7 @@ def _convert_list_to_array(workspace: dict, members: list) -> Array:
     rebuilt_members = array()
     rebuilt_members.extend(members)
     workspace["members"] = rebuilt_members
-    return typ.cast("Array", rebuilt_members)
+    return rebuilt_members
 
 
 def _filter_workspace_members(members: Array) -> bool:

--- a/crate_tools/unittests/test_bump_version.py
+++ b/crate_tools/unittests/test_bump_version.py
@@ -129,10 +129,10 @@ def test_update_markdown_versions_behavior(
         assert updated == expected_text
 
 
-def test_warn_on_markdown_update_failure_logs_warning(
+def test_warn_on_markdown_update_failure_logs_exception(
     tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Log a warning when Markdown updates raise expected exceptions."""
+    """Log the exception with traceback when Markdown updates raise expected errors."""
 
     def raise_toml_error(path: Path, version: str) -> None:  # pragma: no cover - helper
         raise TOMLKitError("boom")
@@ -143,18 +143,18 @@ def test_warn_on_markdown_update_failure_logs_warning(
         "crate_tools.bump_version._update_markdown_versions",
         raise_toml_error,
     )
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("ERROR"):
         _warn_on_markdown_update_failure(md_path, "2.0.0")
     assert any(
         "Failed to update Markdown fence versions" in record.getMessage()
         for record in caplog.records
-    ), "expected warning log when Markdown update raises TOMLKitError"
+    ), "expected error log when Markdown update raises TOMLKitError"
 
 
 def test_warn_on_markdown_update_success_is_silent(
     tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Produce no warnings when Markdown updates succeed."""
+    """Avoid logging when Markdown updates succeed."""
 
     def noop(_: Path, __: str) -> None:  # pragma: no cover - helper
         return
@@ -165,9 +165,9 @@ def test_warn_on_markdown_update_success_is_silent(
         "crate_tools.bump_version._update_markdown_versions",
         noop,
     )
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("ERROR"):
         _warn_on_markdown_update_failure(md_path, "2.0.0")
-    assert not caplog.records, "no warnings expected when Markdown update succeeds"
+    assert not caplog.records, "no error logs expected when Markdown update succeeds"
 
 
 def test_update_markdown_preserves_trailing_newline(tmp_path: Path) -> None:

--- a/crate_tools/unittests/test_bump_version.py
+++ b/crate_tools/unittests/test_bump_version.py
@@ -78,7 +78,7 @@ def test_workspace_dependency_no_version_written() -> None:
 
 
 @pytest.mark.parametrize(
-    ("md_text", "expected_text", "description"),
+    ("md_text", "expected_text"),
     [
         pytest.param(
             """pre
@@ -95,7 +95,6 @@ ortho_config = \"1\"
 ```
 post
 """,
-            "must update TOML fences",
             id="toml-fence",
         ),
         pytest.param(
@@ -111,7 +110,6 @@ echo hi
 ```
 post
 """,
-            "must leave non-TOML fences unchanged",
             id="non-toml-fence",
         ),
     ],
@@ -120,7 +118,6 @@ def test_update_markdown_versions_behavior(
     tmp_path: Path,
     md_text: str,
     expected_text: str,
-    description: str,
 ) -> None:
     """Update Markdown fences only when the language matches TOML."""
     for rel in ("README.md", "docs/users-guide.md"):
@@ -129,7 +126,7 @@ def test_update_markdown_versions_behavior(
         md_path.write_text(md_text)
         _update_markdown_versions(md_path, "1")
         updated = md_path.read_text()
-        assert updated == expected_text, description
+        assert updated == expected_text
 
 
 def test_warn_on_markdown_update_failure_logs_warning(

--- a/crate_tools/unittests/test_bump_version.py
+++ b/crate_tools/unittests/test_bump_version.py
@@ -124,6 +124,7 @@ def test_update_markdown_versions_behavior(
         else:
             assert updated == md_text, description
 
+
 def test_update_markdown_preserves_trailing_newline(tmp_path: Path) -> None:
     """Keep trailing newlines when rewriting Markdown fences."""
     md_text = """```toml

--- a/crate_tools/unittests/test_publish_workspace_dependencies.py
+++ b/crate_tools/unittests/test_publish_workspace_dependencies.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import typing as typ
 
-import publish_workspace_dependencies as dependencies
 import pytest
+
+from crate_tools import publish_workspace_dependencies as dependencies
 
 if typ.TYPE_CHECKING:
     from pathlib import Path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
 pythonVersion = "3.13"
 typeCheckingMode = "strict"
 include = ["crate_tools"]
+exclude = ["crate_tools/unittests", "**/unittests"]
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
## Summary
- adjust type imports, raw docstrings, and markdown error handling in the version bump script to satisfy linting
- document pytest tests, update parametrization, and split long literals to align with docstring and pytest lint rules
- clean up publish helpers by removing blank lines and adopting modern isinstance union syntax

## Testing
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68dddbb2b824832291d6bd9d6fdb3cdd

## Summary by Sourcery

Refactor version bump and publish scripts and associated tests to resolve lint errors by standardizing imports and type hints, adopting modern syntax, normalizing docstrings, and cleaning up test definitions.

Enhancements:
- Update type annotations and imports to use typing.TYPE_CHECKING with a collections.abc alias and PEP 604 union syntax
- Convert docstrings to raw-string (r"""...") format
- Extract inline markdown update error handling into a dedicated helper function and replace os.replace with Path.replace
- Remove extraneous blank lines across scripts

Tests:
- Add descriptive docstrings to pytest tests, rename parameters, employ pytest.param, and split long literals to satisfy lint rules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Improved type safety, safer file updates, and centralized markdown-update warnings for more reliable version and content updates.
- Tests
  - Expanded coverage for dependency/version updates and markdown handling, including quote/comment/indentation preservation and failure logging.
- Chores
  - Type-checking updated to Python 3.13, tooling scripts included in checks, test dirs excluded from type checks, and packaging/import resolution simplified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->