### PR TITLE
Clarify CLI usage error path

### DIFF
--- a/lading/cli.py
+++ b/lading/cli.py
@@ -116,8 +116,8 @@ def main(argv: typ.Sequence[str] | None = None) -> int:
         workspace_override, remaining = _extract_workspace_override(list(argv))
         workspace_root = normalise_workspace_root(workspace_override)
         if not remaining:
-            _dispatch_and_print(remaining)
-            return 2
+            _dispatch_and_print(remaining)  # Print usage message
+            return 2  # Standard exit code for missing subcommand
         with _workspace_env(workspace_root):
             return _dispatch_and_print(remaining)
     except KeyboardInterrupt:


### PR DESCRIPTION
## Summary
- document the intention behind the CLI usage-error path in main()

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e377d8682c8322b4d54ee16e83f6f8

## Summary by Sourcery

Clarify the CLI usage-error path in the main function by adding inline comments to explain printing the usage message and returning exit code 2 for missing subcommands.

Enhancements:
- Add comment to indicate printing of usage message for missing subcommand
- Add comment to explain return code 2 as the standard exit code for missing subcommand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified inline comments in the CLI regarding behavior when no subcommand is provided, noting that usage is displayed and the standard exit code is returned. No functional changes.
* **Chores**
  * Added non-functional annotations to improve code clarity and maintainability. No user-facing impact or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->