### PR TITLE
Load lading configuration for CLI commands

### DIFF
--- a/docs/lading-design.md
+++ b/docs/lading-design.md
@@ -90,6 +90,12 @@ lading [--workspace-root <path>] <subcommand> [options]
 - Behavioural coverage uses `pytest-bdd` with `cmd-mox` spies to exercise the
   CLI through an actual `python -m lading.cli` invocation. This ensures the
   scaffolding works end-to-end, not just through direct function calls.
+- Configuration loading is centralised in `lading/config.py`. The module builds
+  a `cyclopts.config.Toml` loader anchored at the workspace root, validates the
+  resulting data with frozen dataclasses, and exposes a context manager so that
+  downstream code can access the active configuration without passing it through
+  every call. The CLI sets up this context before dispatching a subcommand and
+  falls back to on-demand loading when commands are invoked programmatically.
 
 ### 2.2. Configuration: `lading.toml`
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,7 +22,7 @@
   - **Outcome:** A `cyclopts`-based CLI application is implemented with `bump` and `publish` subcommands.
   - **Completion Criteria:** The CLI runs and correctly dispatches to placeholder functions for each subcommand. It accepts the global `--workspace-root` option.
 
-- [ ] **Configuration Loading:**
+- [x] **Configuration Loading:**
 
   - **Outcome:** The tool can locate and parse a `lading.toml` file from the workspace root.
   - **Completion Criteria:** A Pydantic or dataclass model for `lading.toml` is defined. The CLI successfully loads and validates the configuration file, making its values accessible to the application.

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -37,12 +37,37 @@ resolved path is also exported as the `LADING_WORKSPACE_ROOT` environment
 variable so that downstream helpers and configuration loading can share the
 location without re-parsing CLI arguments.
 
+## Configuration file: `lading.toml`
+
+`lading` expects a `lading.toml` file at the workspace root. The CLI resolves
+the workspace directory, uses `cyclopts`' TOML loader to read the file, and
+exposes the resulting configuration to the active command. The configuration is
+validated with a dataclass-backed model to ensure that string lists and boolean
+flags conform to the schema described in the design document.
+
+An example minimal configuration looks like:
+
+```toml
+[bump]
+doc_files = ["README.md"]
+
+[publish]
+strip_patches = "all"
+```
+
+If the file is missing or contains invalid values the CLI prints a descriptive
+error and exits with a non-zero status. Commands invoked programmatically via
+`python -m lading.cli` load the configuration on demand, so helper scripts and
+tests can continue to exercise the commands directly as long as the file is
+present.
+
 ## Subcommands
 
 ### `bump`
 
 The `bump` command currently emits a placeholder acknowledgement confirming the
-selected workspace. Future roadmap items will replace this with the version
+selected workspace and summarising the documentation files listed in the
+configuration. Future roadmap items will replace this with the version
 propagation workflow described in the design document.
 
 ```bash
@@ -51,9 +76,9 @@ python -m lading.cli --workspace-root /workspace/path bump
 
 ### `publish`
 
-`publish` is scaffolded in the same fashion. It acknowledges the workspace and
-returns successfully. Publication planning and execution will arrive in later
-phases of the roadmap.
+`publish` is scaffolded in the same fashion. It acknowledges the workspace,
+reports the configured `strip_patches` strategy, and returns successfully.
+Publication planning and execution will arrive in later phases of the roadmap.
 
 ```bash
 python -m lading.cli --workspace-root /workspace/path publish

--- a/lading/commands/bump.py
+++ b/lading/commands/bump.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import typing as typ
 
+from lading import config as config_module
 from lading.utils import normalise_workspace_root
 
 if typ.TYPE_CHECKING:
     from pathlib import Path
 
+    from lading.config import LadingConfig
 
-def run(workspace_root: Path) -> str:
+
+def run(workspace_root: Path, configuration: LadingConfig | None = None) -> str:
     """Return a placeholder message for the bump command.
 
     Step 1.1 only wires the CLI, so we provide a friendly acknowledgement
@@ -19,4 +22,8 @@ def run(workspace_root: Path) -> str:
     behaviour.
     """
     root_path = normalise_workspace_root(workspace_root)
-    return f"bump placeholder invoked for {root_path}"
+    if configuration is None:
+        configuration = config_module.current_configuration()
+    doc_files = configuration.bump.doc_files
+    doc_files_summary = ", ".join(doc_files) if doc_files else "none"
+    return f"bump placeholder invoked for {root_path} (doc files: {doc_files_summary})"

--- a/lading/commands/publish.py
+++ b/lading/commands/publish.py
@@ -4,13 +4,21 @@ from __future__ import annotations
 
 import typing as typ
 
+from lading import config as config_module
 from lading.utils import normalise_workspace_root
 
 if typ.TYPE_CHECKING:
     from pathlib import Path
 
+    from lading.config import LadingConfig
 
-def run(workspace_root: Path) -> str:
+
+def run(workspace_root: Path, configuration: LadingConfig | None = None) -> str:
     """Return a placeholder message for the publish command."""
     root_path = normalise_workspace_root(workspace_root)
-    return f"publish placeholder invoked for {root_path}"
+    if configuration is None:
+        configuration = config_module.current_configuration()
+    strip_patches = configuration.publish.strip_patches
+    return (
+        f"publish placeholder invoked for {root_path} (strip patches: {strip_patches})"
+    )

--- a/lading/config.py
+++ b/lading/config.py
@@ -1,0 +1,197 @@
+"""Configuration loading for the :mod:`lading` toolkit."""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import dataclasses as dc
+import typing as typ
+from collections import abc as cabc
+
+from cyclopts.config import Toml
+
+from lading.utils import normalise_workspace_root
+
+if typ.TYPE_CHECKING:
+    from pathlib import Path
+
+CONFIG_FILENAME = "lading.toml"
+
+StripPatchesSetting = typ.Literal["all", "per-crate"] | bool
+
+
+class ConfigurationError(RuntimeError):
+    """Raised when the :mod:`lading` configuration is invalid."""
+
+
+class ConfigurationNotLoadedError(ConfigurationError):
+    """Raised when code accesses the configuration before it is loaded."""
+
+
+class MissingConfigurationError(ConfigurationError):
+    """Raised when the configuration file cannot be located."""
+
+
+@dc.dataclass(frozen=True)
+class BumpConfig:
+    """Settings for the ``bump`` command."""
+
+    doc_files: tuple[str, ...] = ()
+    exclude: tuple[str, ...] = ()
+
+    @classmethod
+    def from_mapping(cls, mapping: cabc.Mapping[str, typ.Any] | None) -> BumpConfig:
+        """Create a :class:`BumpConfig` from a TOML table mapping."""
+        if mapping is None:
+            return cls()
+        return cls(
+            doc_files=_string_tuple(mapping.get("doc_files"), "bump.doc_files"),
+            exclude=_string_tuple(mapping.get("exclude"), "bump.exclude"),
+        )
+
+
+@dc.dataclass(frozen=True)
+class PublishConfig:
+    """Settings for the ``publish`` command."""
+
+    exclude: tuple[str, ...] = ()
+    order: tuple[str, ...] = ()
+    strip_patches: StripPatchesSetting = "per-crate"
+
+    @classmethod
+    def from_mapping(cls, mapping: cabc.Mapping[str, typ.Any] | None) -> PublishConfig:
+        """Create a :class:`PublishConfig` from a TOML table mapping."""
+        if mapping is None:
+            return cls()
+        return cls(
+            exclude=_string_tuple(mapping.get("exclude"), "publish.exclude"),
+            order=_string_tuple(mapping.get("order"), "publish.order"),
+            strip_patches=_strip_patches(mapping.get("strip_patches")),
+        )
+
+
+@dc.dataclass(frozen=True)
+class LadingConfig:
+    """Strongly-typed representation of ``lading.toml``."""
+
+    bump: BumpConfig = dc.field(default_factory=BumpConfig)
+    publish: PublishConfig = dc.field(default_factory=PublishConfig)
+
+    @classmethod
+    def from_mapping(cls, mapping: cabc.Mapping[str, typ.Any]) -> LadingConfig:
+        """Create a :class:`LadingConfig` from a parsed configuration mapping."""
+        return cls(
+            bump=BumpConfig.from_mapping(
+                _optional_mapping(mapping.get("bump"), "bump")
+            ),
+            publish=PublishConfig.from_mapping(
+                _optional_mapping(mapping.get("publish"), "publish")
+            ),
+        )
+
+
+_active_config: contextvars.ContextVar[LadingConfig] = contextvars.ContextVar(
+    "lading_active_config"
+)
+
+
+def build_loader(workspace_root: Path) -> Toml:
+    """Return a Cyclopts loader for ``lading.toml`` in ``workspace_root``."""
+    resolved = normalise_workspace_root(workspace_root)
+    return Toml(
+        path=resolved / CONFIG_FILENAME,
+        must_exist=True,
+        search_parents=False,
+        allow_unknown=True,
+        use_commands_as_keys=True,
+    )
+
+
+def load_from_loader(loader: Toml) -> LadingConfig:
+    """Load and validate configuration using ``loader``."""
+    try:
+        raw = loader.config
+    except FileNotFoundError as exc:
+        missing_path = exc.filename or str(loader.path)
+        message = f"Configuration file not found: {missing_path}"
+        raise MissingConfigurationError(message) from exc
+    if not isinstance(raw, cabc.Mapping):
+        message = "Configuration root must be a TOML table."
+        raise ConfigurationError(message)
+    return LadingConfig.from_mapping(raw)
+
+
+def load_configuration(workspace_root: Path) -> LadingConfig:
+    """Load configuration for ``workspace_root`` using Cyclopts."""
+    loader = build_loader(workspace_root)
+    return load_from_loader(loader)
+
+
+@contextlib.contextmanager
+def use_configuration(configuration: LadingConfig) -> typ.Iterator[None]:
+    """Set ``configuration`` as the active configuration for the current context."""
+    token = _active_config.set(configuration)
+    try:
+        yield
+    finally:
+        _active_config.reset(token)
+
+
+def current_configuration() -> LadingConfig:
+    """Return the active configuration or raise if none has been set."""
+    try:
+        return _active_config.get()
+    except LookupError as exc:  # pragma: no cover - defensive guard
+        message = "Configuration has not been loaded yet."
+        raise ConfigurationNotLoadedError(message) from exc
+
+
+def _string_tuple(value: object, field_name: str) -> tuple[str, ...]:
+    """Return a tuple of strings derived from ``value``."""
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, cabc.Sequence) and not isinstance(value, str | bytes):
+        items: list[str] = []
+        for index, entry in enumerate(value):
+            if not isinstance(entry, str):
+                message = (
+                    f"{field_name}[{index}] must be a string, "
+                    f"got {type(entry).__name__}."
+                )
+                raise ConfigurationError(message)
+            items.append(entry)
+        return tuple(items)
+    message = (
+        f"{field_name} must be a string or a sequence of strings; "
+        f"received {type(value).__name__}."
+    )
+    raise ConfigurationError(message)
+
+
+def _strip_patches(value: object) -> StripPatchesSetting:
+    """Normalise the ``publish.strip_patches`` value."""
+    if value is None:
+        return "per-crate"
+    if value in {"all", "per-crate"}:
+        return typ.cast("StripPatchesSetting", value)
+    if value is False:
+        return False
+    if value is True:
+        message = "publish.strip_patches may be 'all', 'per-crate', or false."
+        raise ConfigurationError(message)
+    message = "publish.strip_patches must be 'all', 'per-crate', or false."
+    raise ConfigurationError(message)
+
+
+def _optional_mapping(
+    value: object, field_name: str
+) -> cabc.Mapping[str, typ.Any] | None:
+    """Ensure ``value`` is a mapping if provided."""
+    if value is None:
+        return None
+    if isinstance(value, cabc.Mapping):
+        return value
+    message = f"{field_name} must be a TOML table; received {type(value).__name__}."
+    raise ConfigurationError(message)

--- a/lading/config.py
+++ b/lading/config.py
@@ -154,8 +154,7 @@ def _validate_string_sequence(
     for index, entry in enumerate(sequence):
         if not isinstance(entry, str):
             message = (
-                f"{field_name}[{index}] must be a string, "
-                f"got {type(entry).__name__}."
+                f"{field_name}[{index}] must be a string, got {type(entry).__name__}."
             )
             raise ConfigurationError(message)
         items.append(entry)

--- a/lading/config.py
+++ b/lading/config.py
@@ -146,6 +146,22 @@ def current_configuration() -> LadingConfig:
         raise ConfigurationNotLoadedError(message) from exc
 
 
+def _validate_string_sequence(
+    sequence: cabc.Sequence[typ.Any], field_name: str
+) -> tuple[str, ...]:
+    """Validate that ``sequence`` contains only strings and return them."""
+    items: list[str] = []
+    for index, entry in enumerate(sequence):
+        if not isinstance(entry, str):
+            message = (
+                f"{field_name}[{index}] must be a string, "
+                f"got {type(entry).__name__}."
+            )
+            raise ConfigurationError(message)
+        items.append(entry)
+    return tuple(items)
+
+
 def _string_tuple(value: object, field_name: str) -> tuple[str, ...]:
     """Return a tuple of strings derived from ``value``."""
     if value is None:
@@ -153,16 +169,7 @@ def _string_tuple(value: object, field_name: str) -> tuple[str, ...]:
     if isinstance(value, str):
         return (value,)
     if isinstance(value, cabc.Sequence) and not isinstance(value, str | bytes):
-        items: list[str] = []
-        for index, entry in enumerate(value):
-            if not isinstance(entry, str):
-                message = (
-                    f"{field_name}[{index}] must be a string, "
-                    f"got {type(entry).__name__}."
-                )
-                raise ConfigurationError(message)
-            items.append(entry)
-        return tuple(items)
+        return _validate_string_sequence(value, field_name)
     message = (
         f"{field_name} must be a string or a sequence of strings; "
         f"received {type(value).__name__}."

--- a/tests/bdd/features/cli.feature
+++ b/tests/bdd/features/cli.feature
@@ -1,10 +1,10 @@
 Feature: Lading CLI scaffolding
   Scenario: Running the bump command with a workspace root
-    Given a workspace directory
+    Given a workspace directory with configuration
     When I invoke lading bump with that workspace
-    Then the command reports the workspace path
+    Then the command reports the workspace path and doc files
 
   Scenario: Running the publish command with a workspace root
-    Given a workspace directory
+    Given a workspace directory with configuration
     When I invoke lading publish with that workspace
-    Then the publish command reports the workspace path
+    Then the publish command reports the workspace path and strip patches

--- a/tests/bdd/features/cli.feature
+++ b/tests/bdd/features/cli.feature
@@ -8,3 +8,8 @@ Feature: Lading CLI scaffolding
     Given a workspace directory with configuration
     When I invoke lading publish with that workspace
     Then the publish command reports the workspace path and strip patches
+
+  Scenario: Running the bump command without configuration
+    Given a workspace directory without configuration
+    When I invoke lading bump with that workspace
+    Then the CLI reports a missing configuration error

--- a/tests/bdd/steps/test_cli_steps.py
+++ b/tests/bdd/steps/test_cli_steps.py
@@ -27,6 +27,15 @@ def given_workspace_directory(tmp_path: Path) -> Path:
     return tmp_path
 
 
+@given(
+    "a workspace directory without configuration",
+    target_fixture="workspace_directory",
+)
+def given_workspace_without_configuration(tmp_path: Path) -> Path:
+    """Provide a workspace root without a configuration file."""
+    return tmp_path
+
+
 def _run_cli(
     cmd_mox: CmdMox,
     repo_root: Path,
@@ -96,3 +105,14 @@ def then_publish_reports_workspace(cli_run: dict[str, typ.Any]) -> None:
     stdout = cli_run["stdout"]
     assert f"publish placeholder invoked for {workspace}" in stdout
     assert "(strip patches: all)" in stdout
+
+
+@then("the CLI reports a missing configuration error")
+def then_cli_reports_missing_configuration(cli_run: dict[str, typ.Any]) -> None:
+    """Assert the CLI surfaces missing configuration errors."""
+    assert cli_run["returncode"] == 1
+    stderr = cli_run["stderr"]
+    expected_path = cli_run["workspace"] / config_module.CONFIG_FILENAME
+    assert (
+        f"Configuration error: Configuration file not found: {expected_path}" in stderr
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import textwrap
 import typing as typ
 from pathlib import Path
 
@@ -30,3 +31,30 @@ def _restore_workspace_env() -> typ.Iterator[None]:
             os.environ.pop(WORKSPACE_ROOT_ENV_VAR, None)
         else:
             os.environ[WORKSPACE_ROOT_ENV_VAR] = original
+
+
+@pytest.fixture
+def write_config(tmp_path: Path) -> typ.Callable[[str], Path]:
+    """Return a helper that writes ``lading.toml`` into ``tmp_path``."""
+    from lading import config as config_module
+
+    def _write(body: str) -> Path:
+        config_path = tmp_path / config_module.CONFIG_FILENAME
+        config_path.write_text(textwrap.dedent(body).lstrip())
+        return config_path
+
+    return _write
+
+
+@pytest.fixture
+def minimal_config(write_config: typ.Callable[[str], Path]) -> Path:
+    """Persist a representative configuration file for CLI exercises."""
+    return write_config(
+        """
+        [bump]
+        doc_files = ["README.md"]
+
+        [publish]
+        strip_patches = "all"
+        """
+    )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -172,6 +172,20 @@ def test_main_handles_invalid_subcommand(
     assert "Unknown command" in captured.out
 
 
+def test_main_reports_missing_configuration(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    """Return a clear error when configuration is missing."""
+    exit_code = cli.main(["bump", "--workspace-root", str(tmp_path)])
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    expected_path = tmp_path.resolve() / config_module.CONFIG_FILENAME
+    assert (
+        f"Configuration error: Configuration file not found: {expected_path}"
+        in captured.err
+    )
+
+
 @pytest.mark.parametrize(
     "case",
     [

--- a/tests/unit/test_commands_placeholder.py
+++ b/tests/unit/test_commands_placeholder.py
@@ -37,6 +37,25 @@ def test_command_run_normalises_paths(
     assert str(expected) in message
 
 
+@pytest.mark.parametrize(
+    "command",
+    [bump.run, publish.run],
+)
+def test_command_run_fallbacks_to_current_configuration(
+    command: typ.Callable[[Path], str],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Commands fall back to the active configuration when none is provided."""
+    workspace = Path("workspace")
+    monkeypatch.chdir(tmp_path)
+    fallback_config = _make_config()
+    monkeypatch.setattr(config_module, "current_configuration", lambda: fallback_config)
+    message = command(workspace)
+    expected = normalise_workspace_root(workspace)
+    assert str(expected) in message
+
+
 def test_bump_run_mentions_command(tmp_path: Path) -> None:
     """The bump placeholder response includes the command name."""
     message = bump.run(tmp_path, _make_config())

--- a/tests/unit/test_commands_placeholder.py
+++ b/tests/unit/test_commands_placeholder.py
@@ -7,8 +7,17 @@ from pathlib import Path
 
 import pytest
 
+from lading import config as config_module
 from lading.commands import bump, publish
 from lading.utils import normalise_workspace_root
+
+
+def _make_config() -> config_module.LadingConfig:
+    """Create a representative configuration instance for placeholder tests."""
+    return config_module.LadingConfig(
+        bump=config_module.BumpConfig(doc_files=("README.md",)),
+        publish=config_module.PublishConfig(strip_patches="all"),
+    )
 
 
 @pytest.mark.parametrize(
@@ -16,25 +25,29 @@ from lading.utils import normalise_workspace_root
     [bump.run, publish.run],
 )
 def test_command_run_normalises_paths(
-    command: typ.Callable[[Path], str],
+    command: typ.Callable[[Path, config_module.LadingConfig], str],
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     """Ensure the placeholder commands resolve to absolute paths."""
     workspace = Path("workspace")
     monkeypatch.chdir(tmp_path)
-    message = command(workspace)
+    message = command(workspace, _make_config())
     expected = normalise_workspace_root(workspace)
-    assert message.endswith(str(expected))
+    assert str(expected) in message
 
 
 def test_bump_run_mentions_command(tmp_path: Path) -> None:
     """The bump placeholder response includes the command name."""
-    message = bump.run(tmp_path)
-    assert message == f"bump placeholder invoked for {tmp_path.resolve()}"
+    message = bump.run(tmp_path, _make_config())
+    assert message == (
+        f"bump placeholder invoked for {tmp_path.resolve()} (doc files: README.md)"
+    )
 
 
 def test_publish_run_mentions_command(tmp_path: Path) -> None:
     """The publish placeholder response includes the command name."""
-    message = publish.run(tmp_path)
-    assert message == f"publish placeholder invoked for {tmp_path.resolve()}"
+    message = publish.run(tmp_path, _make_config())
+    assert message == (
+        f"publish placeholder invoked for {tmp_path.resolve()} (strip patches: all)"
+    )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,89 @@
+"""Tests for ``lading.config``."""
+
+from __future__ import annotations
+
+import textwrap
+import typing as typ
+
+import pytest
+
+from lading import config as config_module
+
+if typ.TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_config(tmp_path: Path, body: str) -> Path:
+    config_path = tmp_path / config_module.CONFIG_FILENAME
+    config_path.write_text(textwrap.dedent(body).lstrip())
+    return config_path
+
+
+def test_load_configuration_parses_values(tmp_path: Path) -> None:
+    """Load a representative configuration document."""
+    _write_config(
+        tmp_path,
+        """
+        [bump]
+        doc_files = ["README.md", "docs/**/*.md"]
+        exclude = ["internal"]
+
+        [publish]
+        exclude = ["examples"]
+        order = ["core"]
+        strip_patches = "all"
+        """,
+    )
+
+    configuration = config_module.load_configuration(tmp_path)
+
+    assert configuration.bump.doc_files == ("README.md", "docs/**/*.md")
+    assert configuration.bump.exclude == ("internal",)
+    assert configuration.publish.exclude == ("examples",)
+    assert configuration.publish.order == ("core",)
+    assert configuration.publish.strip_patches == "all"
+
+
+def test_load_configuration_applies_defaults(tmp_path: Path) -> None:
+    """Missing tables fall back to default values."""
+    _write_config(tmp_path, "# empty file still constitutes valid TOML")
+
+    configuration = config_module.load_configuration(tmp_path)
+
+    assert configuration.bump.doc_files == ()
+    assert configuration.publish.strip_patches == "per-crate"
+
+
+def test_load_configuration_requires_file(tmp_path: Path) -> None:
+    """Raise a descriptive error when ``lading.toml`` is absent."""
+    with pytest.raises(config_module.MissingConfigurationError):
+        config_module.load_configuration(tmp_path)
+
+
+def test_invalid_sequence_values_raise(tmp_path: Path) -> None:
+    """Reject non-string entries in sequence fields."""
+    _write_config(
+        tmp_path,
+        """
+        [bump]
+        doc_files = [1]
+        """,
+    )
+
+    with pytest.raises(config_module.ConfigurationError):
+        config_module.load_configuration(tmp_path)
+
+
+def test_use_configuration_sets_context(tmp_path: Path) -> None:
+    """The configuration context manager exposes the active configuration."""
+    _write_config(tmp_path, "")
+    configuration = config_module.load_configuration(tmp_path)
+
+    with pytest.raises(config_module.ConfigurationNotLoadedError):
+        config_module.current_configuration()
+
+    with config_module.use_configuration(configuration):
+        assert config_module.current_configuration() is configuration
+
+    with pytest.raises(config_module.ConfigurationNotLoadedError):
+        config_module.current_configuration()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -82,6 +82,34 @@ def test_load_configuration_applies_defaults(tmp_path: Path) -> None:
     assert configuration.publish.strip_patches == "per-crate"
 
 
+def test_load_configuration_rejects_unknown_keys(tmp_path: Path) -> None:
+    """Unknown options should trigger configuration errors."""
+    _write_config(
+        tmp_path,
+        """
+        [publish]
+        unexpected = "value"
+        """,
+    )
+
+    with pytest.raises(config_module.ConfigurationError):
+        config_module.load_configuration(tmp_path)
+
+
+def test_load_configuration_rejects_unknown_sections(tmp_path: Path) -> None:
+    """Unknown tables should trigger configuration errors."""
+    _write_config(
+        tmp_path,
+        """
+        [unknown]
+        value = 1
+        """,
+    )
+
+    with pytest.raises(config_module.ConfigurationError):
+        config_module.load_configuration(tmp_path)
+
+
 def test_load_configuration_requires_file(tmp_path: Path) -> None:
     """Raise a descriptive error when ``lading.toml`` is absent."""
     with pytest.raises(config_module.MissingConfigurationError):


### PR DESCRIPTION
## Summary
- add a dedicated configuration module that loads and validates `lading.toml` via Cyclopts
- update the CLI and placeholder commands to consume the configuration and surface key details in output
- cover the new behaviour with unit/Bdd tests and refresh the documentation/roadmap accordingly

## Testing
- make check-fmt
- make lint
- make typecheck
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e40472ffe48322b32a761d5388b32d

## Summary by Sourcery

Add a dedicated configuration module to load and validate lading.toml, integrate it into the CLI command dispatch and placeholder commands, and update tests and documentation to cover the new behavior.

New Features:
- Centralise configuration loading in a new module that parses and validates lading.toml via Cyclopts into frozen dataclasses
- Update the CLI to load and apply the workspace configuration context before dispatching subcommands, and exit with errors on invalid config
- Extend placeholder bump and publish commands to surface configured doc_files and strip_patches values in their output

Documentation:
- Document the structure and usage of the lading.toml configuration file in the usage guide, design doc, and roadmap

Tests:
- Add unit tests for config loading, validation, and context management
- Enhance CLI, placeholder command, and BDD tests to write and exercise a minimal lading.toml and verify config-driven output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Centralized configuration via workspace lading.toml, automatically loaded and validated by the CLI.
  * Commands run with an active configuration context.
  * bump now reports configured documentation files.
  * publish now reports the configured strip-patches strategy.

* **Documentation**
  * Added configuration guide with loading, validation, error handling, and examples.
  * Updated command docs to reflect configuration-driven behavior.
  * Roadmap updated to mark Configuration Loading as complete.

* **Tests**
  * Expanded BDD and unit tests to validate configuration-driven outputs and flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->