### PR TITLE
Implement cargo metadata wrapper

### DIFF
--- a/docs/lading-design.md
+++ b/docs/lading-design.md
@@ -152,6 +152,19 @@ strip_patches = "per-crate"
 
 The tool's internal representation of the workspace is critical for its operation. This model will be constructed at runtime by executing `cargo metadata --format-version 1` and parsing its JSON output. This approach is superior to manual TOML parsing as it correctly handles path dependencies, build scripts, and complex workspace configurations.
 
+#### Implementation notes (Step 1.2)
+
+- Workspace discovery is anchored in `lading.workspace.metadata`. The module uses
+  `plumbum` to construct `cargo metadata --format-version 1`, normalising the
+  workspace root via `lading.utils.normalise_workspace_root` before invoking the
+  command.
+- Failures to locate the `cargo` executable, non-zero exit codes, or malformed
+  JSON payloads raise `CargoMetadataError`. This keeps command execution details
+  contained and provides a consistent error surface for higher layers.
+- The wrapper returns the parsed JSON mapping directly. Later roadmap steps will
+  build dedicated models on top of this structure without re-running the command
+  or reparsing JSON.
+
 The discovery process will populate an internal data structure representing the workspace graph, containing:
 
 - **Workspace Root:** The absolute path to the workspace directory.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,7 +35,7 @@
 
 **Tasks:**
 
-- [ ] **Implement `cargo metadata` Wrapper:**
+- [x] **Implement `cargo metadata` Wrapper:**
 
   - **Outcome:** A Python function exists that executes `cargo metadata --format-version 1` as a subprocess and captures its JSON output.
   - **Completion Criteria:** The function correctly handles command execution errors and returns the parsed JSON data. It is covered by unit tests using a mocked subprocess.

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -91,3 +91,24 @@ Behavioural tests invoke the CLI as an external process and spy on the
 keeps the tests faithful to real user interactions while still providing strict
 control over command invocations. Use the same approach when adding new
 end-to-end scenarios.
+
+## Workspace discovery helpers
+
+Roadmap Step 1.2 introduces a thin wrapper around `cargo metadata` to expose
+workspace information to both commands and library consumers. Import
+`lading.workspace.load_cargo_metadata` to execute the command with the current
+or explicitly provided workspace root:
+
+```python
+from pathlib import Path
+
+from lading.workspace import load_cargo_metadata
+
+metadata = load_cargo_metadata(Path("/path/to/workspace"))
+print(metadata["workspace_root"])
+```
+
+The helper normalises the workspace path, invokes `cargo metadata
+--format-version 1` using `plumbum`, and returns the parsed JSON mapping. Any
+execution errors or invalid output raise `CargoMetadataError` with a descriptive
+message so callers can present actionable feedback to users.

--- a/lading/workspace/__init__.py
+++ b/lading/workspace/__init__.py
@@ -1,0 +1,7 @@
+"""Workspace discovery utilities for :mod:`lading`."""
+
+from __future__ import annotations
+
+from .metadata import CargoMetadataError, load_cargo_metadata
+
+__all__ = ["CargoMetadataError", "load_cargo_metadata"]

--- a/lading/workspace/metadata.py
+++ b/lading/workspace/metadata.py
@@ -1,0 +1,93 @@
+"""Interfaces for invoking ``cargo metadata``."""
+
+from __future__ import annotations
+
+import json
+import typing as typ
+
+from plumbum import local
+from plumbum.commands.processes import CommandNotFound
+
+from lading.utils import normalise_workspace_root
+
+if typ.TYPE_CHECKING:
+    from pathlib import Path
+
+    from plumbum.commands.base import BoundCommand
+
+
+class CargoMetadataError(RuntimeError):
+    """Raised when ``cargo metadata`` cannot be executed successfully."""
+
+
+class CargoExecutableNotFoundError(CargoMetadataError):
+    """Raised when the ``cargo`` executable is missing from ``PATH``."""
+
+    def __init__(self) -> None:
+        """Initialise the error with a descriptive message."""
+        super().__init__("The 'cargo' executable could not be located.")
+
+
+class CargoMetadataInvocationError(CargoMetadataError):
+    """Raised when ``cargo metadata`` exits with a failure code."""
+
+    def __init__(self, exit_code: int, stdout: str, stderr: str) -> None:
+        """Summarise the failing invocation for the caller."""
+        message = stderr.strip() or stdout.strip()
+        if not message:
+            message = f"cargo metadata exited with status {exit_code}"
+        super().__init__(message)
+
+
+class CargoMetadataParseError(CargoMetadataError):
+    """Raised when the command output cannot be parsed."""
+
+    def __init__(self, detail: str) -> None:
+        """Store the underlying parse failure description."""
+        super().__init__(detail)
+
+    @classmethod
+    def invalid_json(cls) -> CargoMetadataParseError:
+        """Return an error indicating malformed JSON output."""
+        return cls("cargo metadata produced invalid JSON output")
+
+    @classmethod
+    def non_object_payload(cls) -> CargoMetadataParseError:
+        """Return an error indicating the payload was not a JSON object."""
+        return cls("cargo metadata returned a non-object JSON payload")
+
+
+def _ensure_command() -> BoundCommand:
+    """Return the ``cargo metadata`` command object."""
+    try:
+        cargo = local["cargo"]
+    except CommandNotFound as exc:  # pragma: no cover - defensive guard
+        raise CargoExecutableNotFoundError from exc
+    return cargo["metadata", "--format-version", "1"]
+
+
+def _coerce_text(value: str | bytes) -> str:
+    """Normalise process output to text."""
+    if isinstance(value, bytes):
+        return value.decode()
+    return value
+
+
+def load_cargo_metadata(
+    workspace_root: Path | str | None = None,
+) -> typ.Mapping[str, typ.Any]:
+    """Execute ``cargo metadata`` and parse the resulting JSON payload."""
+    command = _ensure_command()
+    root_path = normalise_workspace_root(workspace_root)
+    exit_code, stdout, stderr = command.run(retcode=None, cwd=str(root_path))
+    stdout_text = _coerce_text(stdout)
+    stderr_text = _coerce_text(stderr)
+    if exit_code != 0:
+        raise CargoMetadataInvocationError(exit_code, stdout_text, stderr_text)
+    try:
+        payload = json.loads(stdout_text)
+    except json.JSONDecodeError as exc:
+        raise CargoMetadataParseError.invalid_json() from exc
+    if not isinstance(payload, dict):
+        raise CargoMetadataParseError.non_object_payload()
+    return payload

--- a/tests/bdd/features/workspace_metadata.feature
+++ b/tests/bdd/features/workspace_metadata.feature
@@ -1,0 +1,8 @@
+Feature: Cargo metadata discovery
+    Background:
+        Given a workspace directory
+
+    Scenario: Inspecting cargo metadata succeeds
+        Given cargo metadata returns workspace information
+        When I inspect the workspace metadata
+        Then the metadata payload contains the workspace root

--- a/tests/bdd/steps/test_workspace_metadata_steps.py
+++ b/tests/bdd/steps/test_workspace_metadata_steps.py
@@ -1,0 +1,78 @@
+"""BDD steps for the cargo metadata wrapper."""
+
+from __future__ import annotations
+
+import json
+import os
+import typing as typ
+
+from cmd_mox.ipc import Invocation
+from pytest_bdd import given, scenarios, then, when
+
+from lading.workspace import load_cargo_metadata
+from lading.workspace import metadata as metadata_module
+
+if typ.TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+    from cmd_mox import CmdMox
+
+scenarios("../features/workspace_metadata.feature")
+
+
+def _install_cargo_stub(cmd_mox: CmdMox, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace ``_ensure_command`` with a shim using :mod:`cmd_mox`."""
+
+    class _StubCommand:
+        def run(
+            self,
+            *,
+            retcode: int | None = None,
+            cwd: str | os.PathLike[str] | None = None,
+        ) -> tuple[int, str, str]:
+            invocation = Invocation(
+                command="cargo",
+                args=["metadata", "--format-version", "1"],
+                stdin="",
+                env=dict(os.environ),
+            )
+            response = cmd_mox._handle_invocation(invocation)
+            return response.exit_code, response.stdout, response.stderr
+
+    monkeypatch.setattr(metadata_module, "_ensure_command", lambda: _StubCommand())
+
+
+@given("a workspace directory", target_fixture="workspace_directory")
+def given_workspace_directory(tmp_path: Path) -> Path:
+    """Provide a workspace root for discovery exercises."""
+    return tmp_path
+
+
+@given("cargo metadata returns workspace information")
+def given_cargo_metadata_response(
+    cmd_mox: CmdMox,
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_directory: Path,
+) -> None:
+    """Stub the ``cargo metadata`` command for discovery tests."""
+    _install_cargo_stub(cmd_mox, monkeypatch)
+    payload = {"workspace_root": str(workspace_directory), "packages": []}
+    cmd_mox.mock("cargo").with_args("metadata", "--format-version", "1").returns(
+        exit_code=0,
+        stdout=json.dumps(payload),
+    )
+
+
+@when("I inspect the workspace metadata", target_fixture="metadata_payload")
+def when_inspect_metadata(workspace_directory: Path) -> typ.Mapping[str, typ.Any]:
+    """Execute the discovery helper against the stubbed command."""
+    return load_cargo_metadata(workspace_directory)
+
+
+@then("the metadata payload contains the workspace root")
+def then_metadata_contains_workspace(
+    metadata_payload: typ.Mapping[str, typ.Any], workspace_directory: Path
+) -> None:
+    """Assert that the workspace root was parsed from the JSON payload."""
+    assert metadata_payload["workspace_root"] == str(workspace_directory)

--- a/tests/unit/test_workspace_metadata.py
+++ b/tests/unit/test_workspace_metadata.py
@@ -1,0 +1,88 @@
+"""Tests for the ``cargo metadata`` wrapper."""
+
+from __future__ import annotations
+
+import json
+import os
+import typing as typ
+
+import pytest
+from cmd_mox.ipc import Invocation
+
+from lading.workspace import CargoMetadataError, load_cargo_metadata
+from lading.workspace import metadata as metadata_module
+
+if typ.TYPE_CHECKING:
+    from pathlib import Path
+
+    from cmd_mox import CmdMox
+
+
+def _install_cargo_stub(cmd_mox: CmdMox, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace ``_ensure_command`` with a shim using :mod:`cmd_mox`."""
+
+    class _StubCommand:
+        def run(
+            self,
+            *,
+            retcode: int | None = None,
+            cwd: str | os.PathLike[str] | None = None,
+        ) -> tuple[int, str, str]:
+            invocation = Invocation(
+                command="cargo",
+                args=["metadata", "--format-version", "1"],
+                stdin="",
+                env=dict(os.environ),
+            )
+            response = cmd_mox._handle_invocation(invocation)
+            return response.exit_code, response.stdout, response.stderr
+
+    monkeypatch.setattr(metadata_module, "_ensure_command", lambda: _StubCommand())
+
+
+def test_load_cargo_metadata_parses_output(
+    cmd_mox: CmdMox, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Successful invocations should return parsed JSON payloads."""
+    _install_cargo_stub(cmd_mox, monkeypatch)
+    payload = {"workspace_root": "./", "packages": []}
+    cmd_mox.mock("cargo").with_args("metadata", "--format-version", "1").returns(
+        exit_code=0,
+        stdout=json.dumps(payload),
+    )
+
+    result = load_cargo_metadata(tmp_path)
+
+    assert result == payload
+
+
+def test_load_cargo_metadata_raises_on_failure(
+    cmd_mox: CmdMox, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Non-zero exit codes should raise :class:`CargoMetadataError`."""
+    _install_cargo_stub(cmd_mox, monkeypatch)
+    cmd_mox.mock("cargo").with_args("metadata", "--format-version", "1").returns(
+        exit_code=101,
+        stderr="could not read manifest",
+    )
+
+    with pytest.raises(CargoMetadataError) as excinfo:
+        load_cargo_metadata(tmp_path)
+
+    assert "could not read manifest" in str(excinfo.value)
+
+
+def test_load_cargo_metadata_validates_json(
+    cmd_mox: CmdMox, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Invalid JSON payloads should raise :class:`CargoMetadataError`."""
+    _install_cargo_stub(cmd_mox, monkeypatch)
+    cmd_mox.mock("cargo").with_args("metadata", "--format-version", "1").returns(
+        exit_code=0,
+        stdout="[]",
+    )
+
+    with pytest.raises(CargoMetadataError) as excinfo:
+        load_cargo_metadata(tmp_path)
+
+    assert "non-object" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- add a `lading.workspace` package with a cargo metadata runner that normalises the workspace path and surfaces typed errors
- document the workspace discovery helper and mark roadmap Step 1.2 task as complete
- cover the helper with cmd-mox backed unit tests and a behavioural scenario

## Testing
- make check-fmt
- make lint
- make typecheck
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e5b1bd9d6083228fdd924050472f8b